### PR TITLE
feat: templated secondary entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Card can be configured through visual editor or by `yaml`.
 | header_position | `string` | `top` | Header position (`top`, `bottom`)
 | needle | `boolean` | `false` | 
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
-| secondary_entity | `object` | Optional | Secondary info to display under the state, see [secondary entity object](#secondary-entity-object)
+| secondary | `object` or `string` | Optional | Secondary info to display under the state, see [secondary entity object](#secondary-entity-object). May contain [templates](https://www.home-assistant.io/docs/configuration/templating/) see [example](#gauge-with-templated-additional-info-and-segments)
 
 ### Color segment object
 | Name | Type | Default | Description |
@@ -65,7 +65,58 @@ Card can be configured through visual editor or by `yaml`.
 |------|:----:|:-------:|:------------|
 | entity | `string` | Optional | Secondary entity
 | unit | `string` | Optional | Custom unit
-| template | `string` | Optional | 
+
+## Examples
+
+### Simple gauge
+
+```yaml
+type: custom:modern-circular-gauge
+entity: sensor.power_consumption
+max: 1000
+```
+
+### Gauge with additional info
+
+```yaml
+type: custom:modern-circular-gauge
+entity: sensor.power_consumption
+secondary:
+  entity: input_number.voltage
+max: 1000
+```
+
+### Gauge with templated additional info and segments
+
+```yaml
+type: custom:modern-circular-gauge
+entity: sensor.room_temp
+unit: °C
+name: Temperature
+secondary: >-
+  {% if is_state("binary_sensor.room_temp_rising", "on") %} Rising {% elif
+  is_state("binary_sensor.room_temp_falling", "on") %} Falling {% endif %}
+max: 30
+min: 10
+header_position: bottom
+needle: true
+segments:
+  - from: 13
+    color:
+      - 11
+      - 182
+      - 239
+  - from: 19
+    color:
+      - 43
+      - 255
+      - 0
+  - from: 24
+    color:
+      - 252
+      - 161
+      - 3
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Card can be configured through visual editor or by `yaml`.
 | header_position | `string` | `top` | Header position (`top`, `bottom`)
 | needle | `boolean` | `false` | 
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
-| secondary_entity | `object` | Optional | Secondary entity to display under the state, see [secondary entity object](#secondary-entity-object)
+| secondary_entity | `object` | Optional | Secondary info to display under the state, see [secondary entity object](#secondary-entity-object)
 
 ### Color segment object
 | Name | Type | Default | Description |
@@ -63,8 +63,9 @@ Card can be configured through visual editor or by `yaml`.
 ### Secondary entity object
 | Name | Type | Default | Description |
 |------|:----:|:-------:|:------------|
-| entity | `string` | Required | Secondary entity
+| entity | `string` | Optional | Secondary entity
 | unit | `string` | Optional | Custom unit
+| template | `string` | Optional | 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ max: 1000
 type: custom:modern-circular-gauge
 entity: sensor.power_consumption
 secondary:
-  entity: input_number.voltage
+  entity: sensor.voltage
 max: 1000
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Card can be configured through visual editor or by `yaml`.
 
 ### Simple gauge
 
+![simple_gauge](https://github.com/user-attachments/assets/3b895d21-2f03-4eea-903a-43590e687846)
+
 ```yaml
 type: custom:modern-circular-gauge
 entity: sensor.power_consumption
@@ -77,6 +79,8 @@ max: 1000
 ```
 
 ### Gauge with additional info
+
+![simple_gauge_secondary_info](https://github.com/user-attachments/assets/93a411ef-88b1-477b-b6f7-896cdc32dbff)
 
 ```yaml
 type: custom:modern-circular-gauge
@@ -87,6 +91,8 @@ max: 1000
 ```
 
 ### Gauge with templated additional info and segments
+
+![gauge_templates](https://github.com/user-attachments/assets/b4cc720b-7433-4729-b09e-3800ea578de3)
 
 ```yaml
 type: custom:modern-circular-gauge

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -42,7 +42,7 @@ const FORM = [
         ],
     },
     {
-        name: "secondary_entity",
+        name: "secondary",
         type: "expandable",
         label: "Secondary info",
         iconPath: mdiInformationOutline,
@@ -56,10 +56,6 @@ const FORM = [
             {
                 name: "unit",
                 selector: { text: {} },
-            },
-            {
-                name: "template",
-                selector: { template: {} },
             }
         ],
     },
@@ -121,7 +117,20 @@ export class ModernCircularGaugeEditor extends LitElement {
     @state() private _config?: ModernCircularGaugeConfig;
 
     setConfig(config: ModernCircularGaugeConfig): void {
-        this._config = config;
+        let secondary = config.secondary;
+
+        if (secondary === undefined && config.secondary_entity !== undefined) {
+            secondary = config.secondary_entity;
+        }
+        
+        if (typeof secondary === "object") {
+            const template = secondary.template || "";
+            if (template.length > 0) {
+                secondary = template;
+            }
+        }
+
+        this._config = { ...config, secondary: secondary, secondary_entity: undefined };
     }
 
     protected render() {
@@ -231,12 +240,26 @@ export class ModernCircularGaugeEditor extends LitElement {
     }
 
     private _valueChanged(ev: CustomEvent): void {
-        let config = ev.detail.value;
+        let config = ev.detail.value as ModernCircularGaugeConfig;
         if (!config) {
             return;
         }
 
-        fireEvent(this, "config-changed", { config });
+        let secondary = this._config?.secondary;
+
+        if (typeof config.secondary === "object") {
+            if (config.secondary.entity !== undefined) {
+                secondary = {
+                    entity: config.secondary.entity,
+                    unit: config.secondary.unit || undefined
+                };
+            }
+            if (config.secondary.template !== undefined) {
+                secondary = config.secondary.template;
+            }
+        }
+
+        fireEvent(this, "config-changed", { config: { ...config, secondary } });
     }
 
     static get styles() {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -254,6 +254,9 @@ export class ModernCircularGaugeEditor extends LitElement {
                     unit: config.secondary.unit || undefined
                 };
             }
+            else {
+                secondary = undefined;
+            }
             if (config.secondary.template !== undefined) {
                 secondary = config.secondary.template;
             }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -44,7 +44,7 @@ const FORM = [
     {
         name: "secondary_entity",
         type: "expandable",
-        label: "Secondary entity",
+        label: "Secondary info",
         iconPath: mdiInformationOutline,
         schema: [
             {
@@ -56,6 +56,10 @@ const FORM = [
             {
                 name: "unit",
                 selector: { text: {} },
+            },
+            {
+                name: "template",
+                selector: { template: {} },
             }
         ],
     },

--- a/src/ha/ws-templates.ts
+++ b/src/ha/ws-templates.ts
@@ -1,0 +1,38 @@
+import { Connection, UnsubscribeFunc } from "home-assistant-js-websocket";
+
+export interface RenderTemplateResult {
+  result: string;
+  listeners: TemplateListeners;
+}
+
+export interface RenderTemplateError {
+  error: string;
+  level: "ERROR" | "WARNING";
+}
+
+interface TemplateListeners {
+  all: boolean;
+  domains: string[];
+  entities: string[];
+  time: boolean;
+} 
+
+export const subscribeRenderTemplate = (
+  conn: Connection,
+  onChange: (result: RenderTemplateResult | RenderTemplateError) => void,
+  params: {
+    template: string;
+    entity_ids?: string | string[];
+    variables?: Record<string, unknown>;
+    timeout?: number;
+    strict?: boolean;
+    report_errors?: boolean;
+  }
+): Promise<UnsubscribeFunc> =>
+  conn.subscribeMessage(
+    (msg: RenderTemplateResult | RenderTemplateError) => onChange(msg),
+    {
+      type: "render_template",
+      ...params,
+    }
+  );

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,8 +109,6 @@ export class ModernCircularGauge extends LitElement {
       return html``;
     }
 
-    console.log(this._templateResult);
-
     const stateObj = this.hass.states[this._config.entity];
 
     if (!stateObj) {

--- a/src/type.ts
+++ b/src/type.ts
@@ -7,8 +7,9 @@ export interface SegmentsConfig {
 }
 
 export type SecondaryEntity = {
-    entity: string;
+    entity?: string;
     unit?: string;
+    template?: string;
 };
 
 export interface ModernCircularGaugeConfig extends LovelaceCardConfig {

--- a/src/type.ts
+++ b/src/type.ts
@@ -21,5 +21,6 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     header_position?: "top" | "bottom";
     needle?: boolean;
     segments?: SegmentsConfig[];
+    secondary?: SecondaryEntity | string;
     secondary_entity?: SecondaryEntity;
 }


### PR DESCRIPTION
Adds ability to use template for displaying secondary info under the state instead of only entity.
closes #10 