### PR TITLE
feat: badge icon and needle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ Templates are supported on selected options, configurable only via `yaml`.
 | type | `string` | 'custom:modern-circular-gauge-badge' |
 | entity | `string` | Required | Entity. May contain templates.
 | name | `string` | Optional | Custom title
+| icon | `string` | Entity icon | Custom icon
 | min | `number` or `string` | `0` | Minimum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | max | `number` or `string` | `100` | Maximum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | unit | `string` | Optional | Custom unit
 | show_name | `bool` | `false` | Show badge name
 | show_state | `bool` | `true` | Show entity state
+| show_icon | `bool` | `false` | Show icon
+| needle | `bool` | `false` | 
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
 
 #### Color segment object

--- a/src/badge/gauge-badge-config.ts
+++ b/src/badge/gauge-badge-config.ts
@@ -7,7 +7,10 @@ export interface ModernCircularGaugeBadgeConfig extends LovelaceBadgeConfig {
   min?: number | string;
   max?: number | string;
   unit?: string;
+  icon?: string;
   show_name?: boolean;
   show_state?: boolean;
+  show_icon?: boolean;
+  needle?: boolean;
   segments?: SegmentsConfig[];
 }

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -65,7 +65,7 @@ const FORM = [
       {
         name: "show_icon",
         label: "Show icon",
-        default: true,
+        default: false,
         selector: { boolean: {} },
       },
     ]

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -29,6 +29,16 @@ const FORM = [
         selector: { text: {} },
       },
       {
+        name: "icon",
+        selector: { icon: {} },
+        context: { icon_entity: "entity" },
+      },
+      {
+        name: "needle",
+        label: "gauge.needle_gauge",
+        selector: { boolean: {} },
+      },
+      {
         name: "min",
         default: DEFAULT_MIN,
         label: "generic.minimum",
@@ -49,6 +59,12 @@ const FORM = [
       {
         name: "show_state",
         label: "Show state",
+        default: true,
+        selector: { boolean: {} },
+      },
+      {
+        name: "show_icon",
+        label: "Show icon",
         default: true,
         selector: { boolean: {} },
       },

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -1,4 +1,4 @@
-import { LitElement, TemplateResult, html, css, nothing, PropertyValues } from "lit";
+import { LitElement, TemplateResult, html, css, nothing, PropertyValues, svg } from "lit";
 import { HomeAssistant } from "../ha/types";
 import { ModernCircularGaugeBadgeConfig } from "./gauge-badge-config";
 import { customElement, property, state } from "lit/decorators.js";
@@ -16,6 +16,7 @@ import { mdiAlertCircle } from "@mdi/js";
 import { rgbToHex } from "../utils/color";
 import { RenderTemplateResult, subscribeRenderTemplate } from "../ha/ws-templates";
 import { isTemplate } from "../utils/template";
+import { SegmentsConfig } from "../card/type";
 
 const MAX_ANGLE = 270;
 const ROTATE_ANGLE = 360 - MAX_ANGLE / 2 - 90;
@@ -254,14 +255,16 @@ export class ModernCircularGaugeBadge extends LitElement {
 
     const numberState = Number(templatedState ?? stateObj.state);
 
-    const unit = this._config.unit ?? stateObj?.attributes.unit_of_measurement;
+    const unit = (this._config.unit ?? stateObj?.attributes.unit_of_measurement) || "";
 
-    const current = this._strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0);
+    const current = this._config.needle ? undefined : this._strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0);
+    const needle = this._config.needle ? this._strokeDashArc(numberState, numberState) : undefined;
     const state = templatedState ?? stateObj.state;
     const entityState = formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
     const name = this._config.name || stateObj?.attributes.friendly_name;
-    const label = this._config.show_name ? name : undefined;
+    const label = this._config.show_name && this._config.show_icon && this._config.show_state ? name : undefined;
+    const content = this._config.show_icon && this._config.show_state ? `${entityState} ${unit}` : this._config.show_name ? name : undefined;
 
     return html`
     <ha-badge
@@ -271,34 +274,67 @@ export class ModernCircularGaugeBadge extends LitElement {
         hasHold: hasAction(this._config.hold_action),
         hasDoubleClick: hasAction(this._config.double_tap_action),
       })}
-      .iconOnly=${!this._config.show_name}
+      .iconOnly=${content === undefined}
       style=${styleMap({ "--gauge-color": this._computeSegments(numberState) })}
+      .label=${label}
     >
-      <div class=${classMap({ "container": true, "icon-only": !this._config.show_name })} slot="icon">
+      <div class=${classMap({ "container": true, "icon-only": content === undefined })} slot="icon">
         <svg class="gauge" viewBox="-50 -50 100 100">
           <g transform="rotate(${ROTATE_ANGLE})">
+          ${needle ? svg`
+            <mask id="needle-mask">
+              <rect x="-50" y="-50" width="100" height="100" fill="white"/>
+              <circle cx="42" cy="0" r="12" fill="black" transform="rotate(${this._getAngle(numberState)})"/>
+            </mask>
+          ` : nothing}
+
             <path
               class="arc clear"
               d=${path}
+              mask="url(#needle-mask)"
             />
+          ${needle ? svg`
+            ${this._config.segments ? svg`
+            <g class="segments" mask="url(#needle-mask)">
+              ${this._renderSegments(this._config.segments)}
+            </g>  
+            ` : nothing}
             <path
-              class="arc current"
+              class="needle"
               d=${path}
-              stroke-dasharray="${current[0]}"
-              stroke-dashoffset="${current[1]}"
+              stroke-dasharray=${needle[0]}
+              stroke-dashoffset=${needle[1]}
             />
+          ` : nothing}
+          ${current ? svg`
+              <path
+                class="arc current"
+                d=${path}
+                stroke-dasharray="${current[0]}"
+                stroke-dashoffset="${current[1]}"
+              />
+          ` : nothing}
           </g>
         </svg>
-        ${this._config.show_state ? html`
-        <svg class="state" viewBox="-50 -50 100 100">
-          <text x="0" y="0" class="value" style=${styleMap({ "font-size": this._calcStateSize(entityState) })}>
-            ${entityState}
-            <tspan class="unit" dx="-4" dy="-6">${unit}</tspan>
-          </text>
-        </svg>
+        ${this._config.show_icon
+          ? html`
+          <ha-state-icon
+            .hass=${this.hass}
+            .stateObj=${stateObj}
+            .icon=${this._config.icon}
+          ></ha-state-icon>`
+          : nothing}
+        ${this._config.show_state && !this._config.show_icon
+          ? html`
+          <svg class="state" viewBox="-50 -50 100 100">
+            <text x="0" y="0" class="value" style=${styleMap({ "font-size": this._calcStateSize(entityState) })}>
+              ${entityState}
+              <tspan class="unit" dx="-4" dy="-6">${unit}</tspan>
+            </text>
+          </svg>
           ` : nothing}
       </div>
-      ${label}
+      ${content}
     </ha-badge>
     `;
   }
@@ -318,6 +354,51 @@ export class ModernCircularGaugeBadge extends LitElement {
       }
     }
     return undefined;
+  }
+
+  private _renderSegments(segments: SegmentsConfig[]): TemplateResult[] {
+    if (segments) {
+      let sortedSegments = [...segments].sort((a, b) => a.from - b.from);
+
+      return [...sortedSegments].map((segment, index) => {
+        let roundEnd: TemplateResult | undefined;
+        const startAngle = index === 0 ? 0 : this._getAngle(segment.from);
+        const angle = index === sortedSegments.length - 1 ? MAX_ANGLE : this._getAngle(sortedSegments[index + 1].from);
+        const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+        const segmentPath = svgArc({
+          x: 0,
+          y: 0,
+          start: startAngle,
+          end: angle,
+          r: RADIUS,
+        });
+
+        if (index === 0 || index === sortedSegments.length - 1) {
+          const endPath = svgArc({
+            x: 0,
+            y: 0,
+            start: index === 0 ? 0 : MAX_ANGLE,
+            end: index === 0 ? 0 : MAX_ANGLE,
+            r: RADIUS,
+          });
+          roundEnd = svg`
+          <path
+            class="segment"
+            stroke=${color}
+            d=${endPath}
+            stroke-linecap="round"
+          />`;
+        }
+
+        return svg`${roundEnd}
+          <path
+            class="segment"
+            stroke=${color}
+            d=${segmentPath}
+          />`;
+      });
+    }
+    return [];
   }
 
   private _calcStateSize(state: string): string {
@@ -378,6 +459,9 @@ export class ModernCircularGaugeBadge extends LitElement {
     }
 
     .container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
       position: relative;
       container-type: normal;
       container-name: container;
@@ -391,6 +475,20 @@ export class ModernCircularGaugeBadge extends LitElement {
     .container.icon-only {
       margin-left: 0;
       margin-inline-start: 0;
+    }
+
+    .gauge {
+      position: absolute;
+    }
+
+    .segment {
+      fill: none;
+      stroke-width: var(--gauge-stroke-width);
+      filter: brightness(100%);
+    }
+
+    .segments {
+      opacity: 0.3;
     }
 
     ha-badge {
@@ -426,6 +524,18 @@ export class ModernCircularGaugeBadge extends LitElement {
 
     .arc.current {
       stroke: var(--gauge-color);
+      transition: all 1s ease 0s;
+    }
+
+    .needle {
+      fill: none;
+      stroke-linecap: round;
+      stroke-width: var(--gauge-stroke-width);
+      stroke: var(--gauge-color);
+      transition: all 1s ease 0s;
+    }
+
+    circle {
       transition: all 1s ease 0s;
     }
     `

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -258,7 +258,6 @@ export class ModernCircularGaugeBadge extends LitElement {
     const unit = (this._config.unit ?? stateObj?.attributes.unit_of_measurement) || "";
 
     const current = this._config.needle ? undefined : this._strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0);
-    const needle = this._config.needle ? this._strokeDashArc(numberState, numberState) : undefined;
     const state = templatedState ?? stateObj.state;
     const entityState = formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
@@ -281,7 +280,7 @@ export class ModernCircularGaugeBadge extends LitElement {
       <div class=${classMap({ "container": true, "icon-only": content === undefined })} slot="icon">
         <svg class="gauge" viewBox="-50 -50 100 100">
           <g transform="rotate(${ROTATE_ANGLE})">
-          ${needle ? svg`
+          ${this._config.needle ? svg`
             <mask id="needle-mask">
               <rect x="-50" y="-50" width="100" height="100" fill="white"/>
               <circle cx="42" cy="0" r="12" fill="black" transform="rotate(${this._getAngle(numberState)})"/>
@@ -293,18 +292,13 @@ export class ModernCircularGaugeBadge extends LitElement {
               d=${path}
               mask="url(#needle-mask)"
             />
-          ${needle ? svg`
+          ${this._config.needle ? svg`
             ${this._config.segments ? svg`
             <g class="segments" mask="url(#needle-mask)">
               ${this._renderSegments(this._config.segments)}
             </g>  
             ` : nothing}
-            <path
-              class="needle"
-              d=${path}
-              stroke-dasharray=${needle[0]}
-              stroke-dashoffset=${needle[1]}
-            />
+            <circle class="needle" cx="42" cy="0" r="7" transform="rotate(${this._getAngle(numberState)})"/>
           ` : nothing}
           ${current ? svg`
               <path
@@ -528,9 +522,7 @@ export class ModernCircularGaugeBadge extends LitElement {
     }
 
     .needle {
-      fill: none;
-      stroke-linecap: round;
-      stroke-width: var(--gauge-stroke-width);
+      fill: var(--gauge-color);
       stroke: var(--gauge-color);
       transition: all 1s ease 0s;
     }

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -251,6 +251,8 @@ export class ModernCircularGaugeBadge extends LitElement {
       }
     }
 
+    const min = Number(this._getValue("min")) ?? DEFAULT_MIN;
+
     const attributes = stateObj?.attributes ?? undefined;
 
     const numberState = Number(templatedState ?? stateObj.state);
@@ -303,6 +305,7 @@ export class ModernCircularGaugeBadge extends LitElement {
           ${current ? svg`
               <path
                 class="arc current"
+                style=${styleMap({ "visibility": numberState <= min && min >= 0 ? "hidden" : "visible" })}
                 d=${path}
                 stroke-dasharray="${current[0]}"
                 stroke-dashoffset="${current[1]}"


### PR DESCRIPTION
Adds needle and icon for gauge badge. Closes #26
![badges](https://github.com/user-attachments/assets/b7d3d2c8-bf9f-4a48-be8b-53b888fbcf96)