### PR TITLE
fix: unable to add segment

### DIFF
--- a/src/components/ha-form-mcg-list.ts
+++ b/src/components/ha-form-mcg-list.ts
@@ -82,6 +82,10 @@ export class MCG_List extends LitElement {
   }
 
   private _addRow() {
+    if (this.data === undefined) {
+      fireEvent(this, "value-changed", { value: [{}] });
+      return;
+    }
     const data = [
       ...this.data,
       {}


### PR DESCRIPTION
On newly added card, segments editor would not allow to add segment. This fixes it.