### PR TITLE
feat: secondary state size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | min | `number` or `string` | `0` | Minimum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | max | `number` or `string` | `100` | Maximum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/) see [example](#gauge-with-templated-additional-info-and-segments)
 | unit | `string` | Optional | Custom unit
+| label | `string` | Optional | Label under the state, only used when `state_size` is set to `big`, see [secondary](#secondary-entity-object)
 | header_position | `string` | `top` | Header position (`top`, `bottom`)
 | needle | `boolean` | `false` | 
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
@@ -75,7 +76,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 |------|:----:|:-------:|:------------|
 | from | `number` | Required | Starting value of color segment
 | color | `string` | Required | Color value of color segment
-| label | `string` | Optional | Color segment label
+| label | `string` | Optional | Color segment label to display instead of state
 
 #### Secondary entity object
 | Name | Type | Default | Description |
@@ -85,6 +86,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_gauge | `none`, `inner`, `outter` | `none` | Display secondary info as dot on main gauge or on inner gauge
 | min | `number` | Optional | Minimum inner gauge value. May contain templates
 | max | `number` | Optional | Maximum inner gauge value. May contain templates
+| label | `string` | Optional | Label under the state, only used when `state_size` is set to `big`
 | state_size | `small` or `big` | `small` | Secondary state size 
 | needle | `boolean` | `false` |
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_gauge | `none`, `inner`, `outter` | `none` | Display secondary info as dot on main gauge or on inner gauge
 | min | `number` | Optional | Minimum inner gauge value. May contain templates
 | max | `number` | Optional | Maximum inner gauge value. May contain templates
+| state_size | `small` or `big` | `small` | Secondary state size 
 | needle | `boolean` | `false` |
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
 

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -73,22 +73,33 @@ export class ModernCircularGaugeEditor extends LitElement {
         label: "Secondary info",
         iconPath: mdiInformationOutline,
         schema: [
-            {
-              name: "",
-              type: "grid",
-              schema: [
-                {
-                  name: "entity",
-                  selector: { entity: { 
-                    domain: NUMBER_ENTITY_DOMAINS,
-                  }},
-                },
-                {
-                  name: "unit",
-                  selector: { text: {} },
-                },
-              ]
-            },
+          {
+            name: "",
+            type: "grid",
+            schema: [
+              {
+                name: "entity",
+                selector: { entity: { 
+                  domain: NUMBER_ENTITY_DOMAINS,
+                }},
+              },
+              {
+                name: "unit",
+                selector: { text: {} },
+              },
+            ]
+          },
+          {
+            name: "state_size",
+            label: "State size",
+            selector: { select: {
+              options: [
+                { value: "small", label: "Small"},
+                { value: "big", label: "Big"},
+              ],
+              mode: "dropdown",
+            }},
+          },
           {
             name: "show_gauge",
             label: "Gauge visibility",

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -305,6 +305,15 @@ export class ModernCircularGauge extends LitElement {
               <tspan class="unit" dx="-4" dy="-6">${unit}</tspan>
             `}
           </text>
+          ${typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big"
+            ? svg`
+          <text
+            class="state-label"
+            dy="1"
+          >
+            ${this._config.label}
+          </text>`
+            : nothing}
           ${this._renderSecondary()}
         </svg>
       </div> 
@@ -476,10 +485,9 @@ export class ModernCircularGauge extends LitElement {
     return svg`
     <text
       @action=${this._handleAction}
-      x="0" y="0"
       class="secondary ${classMap({"dual-state": secondary.state_size == "big"})}"
       style=${styleMap({ "font-size": secondary.state_size == "big" ? this._calcStateSize(entityState) : undefined })}
-      dy=${secondary.state_size == "big" ? 14 : 19}
+      dy=${secondary.state_size == "big" ? 14 : 20}
     >
       ${entityState}
       <tspan
@@ -490,6 +498,15 @@ export class ModernCircularGauge extends LitElement {
         ${unit}
       </tspan>
     </text>
+    ${secondary.state_size == "big"
+      ? svg`
+    <text
+      class="state-label"
+      dy="30"
+    >
+      ${secondary.label}
+    </text>`
+      : nothing}
     `;
   }
 
@@ -788,7 +805,12 @@ export class ModernCircularGauge extends LitElement {
     }
 
     .secondary {
-      font-size: 8px;
+      font-size: 10px;
+      fill: var(--secondary-text-color);
+    }
+
+    .state-label {
+      font-size: 0.49em;
       fill: var(--secondary-text-color);
     }
 

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -799,7 +799,11 @@ export class ModernCircularGauge extends LitElement {
     }
 
     .secondary.dual-state {
-      opacity: 0.7;
+      fill: var(--secondary-text-color);
+    }
+
+    .secondary.dual-state .unit {
+      opacity: 1;
     }
 
     .name {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -502,7 +502,7 @@ export class ModernCircularGauge extends LitElement {
       ? svg`
     <text
       class="state-label"
-      dy="30"
+      dy="29"
     >
       ${secondary.label}
     </text>`

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -478,7 +478,7 @@ export class ModernCircularGauge extends LitElement {
       @action=${this._handleAction}
       x="0" y="0"
       class="secondary ${classMap({"dual-state": secondary.state_size == "big"})}"
-      style=${styleMap({ "font-size": secondary.state_size == "big" ? `calc(${this._calcStateSize(entityState)} - 2px)` : "revert-layer" })}
+      style=${styleMap({ "font-size": secondary.state_size == "big" ? this._calcStateSize(entityState) : undefined })}
       dy=${secondary.state_size == "big" ? 14 : 19}
     >
       ${entityState}

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -13,6 +13,7 @@ export type SecondaryEntity = {
     show_gauge?: "none" | "inner" | "outter";
     min?: number | string;
     max?: number | string;
+    state_size?: "small" | "big";
     needle?: boolean;
     segments?: SegmentsConfig[];
 };

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -9,6 +9,7 @@ export interface SegmentsConfig {
 export type SecondaryEntity = {
     entity?: string;
     unit?: string;
+    label?: string;
     template?: string;
     show_gauge?: "none" | "inner" | "outter";
     min?: number | string;
@@ -24,6 +25,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     min?: number | string;
     max?: number | string;
     unit?: string;
+    label?: string;
     header_position?: "top" | "bottom";
     needle?: boolean;
     segments?: SegmentsConfig[];


### PR DESCRIPTION
This adds two size options for secondary state with ability to display labels under the state:

- `small` - current size (default)
![card_small](https://github.com/user-attachments/assets/44ab2ca3-3e43-46ae-b0ea-1dc58b6c9b05)
- `big` - bigger size
![card](https://github.com/user-attachments/assets/eb5ce0aa-ef98-4e07-a2d8-b590c447067c)
