### PR TITLE
feat: smooth color segments option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | unit | `string` | Optional | Custom unit
 | header_position | `string` | `top` | Header position (`top`, `bottom`)
 | needle | `boolean` | `false` | 
+| smooth_segments | `boolean` | `false` | Smooth color segments
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
 | secondary | `object` or `string` | Optional | Secondary info to display under the state, see [secondary entity object](#secondary-entity-object). May contain [templates](https://www.home-assistant.io/docs/configuration/templating/) see [example](#gauge-with-templated-additional-info-and-segments)
 
@@ -68,6 +69,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_state | `bool` | `true` | Show entity state
 | show_icon | `bool` | `false` | Show icon
 | needle | `bool` | `false` | 
+| smooth_segments | `boolean` | `false` | Smooth color segments
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
 
 #### Color segment object

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@lit-labs/observers": "^2.0.4",
         "@mdi/js": "^7.4.47",
         "custom-card-helpers": "^1.9.0",
+        "d3-interpolate": "^3.0.1",
         "home-assistant-js-websocket": "^9.4.0",
         "lit": "^3.2.0",
         "memoize-one": "^6.0.0"
@@ -2146,6 +2147,27 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@lit-labs/observers": "^2.0.4",
     "@mdi/js": "^7.4.47",
     "custom-card-helpers": "^1.9.0",
+    "d3-interpolate": "^3.0.1",
     "home-assistant-js-websocket": "^9.4.0",
     "lit": "^3.2.0",
     "memoize-one": "^6.0.0"

--- a/src/badge/gauge-badge-config.ts
+++ b/src/badge/gauge-badge-config.ts
@@ -12,5 +12,6 @@ export interface ModernCircularGaugeBadgeConfig extends LovelaceBadgeConfig {
   show_state?: boolean;
   show_icon?: boolean;
   needle?: boolean;
+  smooth_segments?: boolean;
   segments?: SegmentsConfig[];
 }

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -68,6 +68,11 @@ const FORM = [
         default: false,
         selector: { boolean: {} },
       },
+      {
+        name: "smooth_segments",
+        label: "Smooth color segments",
+        selector: { boolean: {} },
+      },
     ]
   },
   {

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -513,7 +513,7 @@ export class ModernCircularGaugeBadge extends LitElement {
     }
 
     .segments {
-      opacity: 0.3;
+      opacity: 0.35;
     }
 
     ha-badge {

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -14,6 +14,7 @@ import { handleAction } from "../ha/handle-action";
 import { actionHandler } from "../utils/action-handler-directive";
 import { mdiAlertCircle } from "@mdi/js";
 import { rgbToHex } from "../utils/color";
+import { interpolateRgb } from "d3-interpolate";
 import { RenderTemplateResult, subscribeRenderTemplate } from "../ha/ws-templates";
 import { isTemplate } from "../utils/template";
 import { SegmentsConfig } from "../card/type";
@@ -182,9 +183,9 @@ export class ModernCircularGaugeBadge extends LitElement {
     );
   }
 
-  private _strokeDashArc(from: number, to: number): [string, string] {
-    const start = this._valueToPercentage(from);
-    const end = this._valueToPercentage(to);
+  private _strokeDashArc(from: number, to: number, min: number, max: number): [string, string] {
+    const start = this._valueToPercentage(from, min, max);
+    const end = this._valueToPercentage(to, min, max);
 
     const track = (RADIUS * 2 * Math.PI * MAX_ANGLE) / 360;
     const arc = Math.max((end - start) * track, 0);
@@ -195,14 +196,12 @@ export class ModernCircularGaugeBadge extends LitElement {
     return [strokeDasharray, strokeDashOffset];
   }
 
-  private _valueToPercentage(value: number) {
-    const min = Number(this._getValue("min")) ?? DEFAULT_MIN;
-    const max = Number(this._getValue("max")) ?? DEFAULT_MAX;
+  private _valueToPercentage(value: number, min: number, max: number) {
     return (clamp(value, min, max) - min) / (max - min);
   }
 
-  private _getAngle(value: number) {
-    return this._valueToPercentage(value) * MAX_ANGLE;
+  private _getAngle(value: number, min: number, max: number) {
+    return this._valueToPercentage(value, min, max) * MAX_ANGLE;
   }
 
   protected render(): TemplateResult {
@@ -252,6 +251,7 @@ export class ModernCircularGaugeBadge extends LitElement {
     }
 
     const min = Number(this._getValue("min")) ?? DEFAULT_MIN;
+    const max = Number(this._getValue("max")) ?? DEFAULT_MAX;
 
     const attributes = stateObj?.attributes ?? undefined;
 
@@ -259,7 +259,7 @@ export class ModernCircularGaugeBadge extends LitElement {
 
     const unit = (this._config.unit ?? stateObj?.attributes.unit_of_measurement) || "";
 
-    const current = this._config.needle ? undefined : this._strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0);
+    const current = this._config.needle ? undefined : this._strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0, min, max);
     const state = templatedState ?? stateObj.state;
     const entityState = formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
@@ -282,12 +282,18 @@ export class ModernCircularGaugeBadge extends LitElement {
       <div class=${classMap({ "container": true, "icon-only": content === undefined })} slot="icon">
         <svg class="gauge" viewBox="-50 -50 100 100">
           <g transform="rotate(${ROTATE_ANGLE})">
-          ${this._config.needle ? svg`
-            <mask id="needle-mask">
-              <rect x="-50" y="-50" width="100" height="100" fill="white"/>
-              <circle cx="42" cy="0" r="12" fill="black" transform="rotate(${this._getAngle(numberState)})"/>
-            </mask>
-          ` : nothing}
+            <defs>
+            ${this._config.needle ? svg`
+              <mask id="needle-mask">
+                <path
+                  class="arc"
+                  stroke="white"
+                  d=${path}
+                />
+                <circle cx="42" cy="0" r="12" fill="black" transform="rotate(${this._getAngle(numberState, min, max)})"/>
+              </mask>
+              ` : nothing}
+            </defs>
 
             <path
               class="arc clear"
@@ -297,10 +303,10 @@ export class ModernCircularGaugeBadge extends LitElement {
           ${this._config.needle ? svg`
             ${this._config.segments ? svg`
             <g class="segments" mask="url(#needle-mask)">
-              ${this._renderSegments(this._config.segments)}
+              ${this._renderSegments(this._config.segments, min, max)}
             </g>  
             ` : nothing}
-            <circle class="needle" cx="42" cy="0" r="7" transform="rotate(${this._getAngle(numberState)})"/>
+            <circle class="needle" cx="42" cy="0" r="7" transform="rotate(${this._getAngle(numberState, min, max)})"/>
           ` : nothing}
           ${current ? svg`
               <path
@@ -345,55 +351,77 @@ export class ModernCircularGaugeBadge extends LitElement {
         let segment = segments[i];
         if (segment && (numberState >= segment.from || i === 0) &&
           (i + 1 == segments?.length || numberState < segments![i + 1].from)) {
-            const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
-            return color;
+            if (this._config?.smooth_segments) {
+              const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+              const nextSegment = segments[i + 1] ? segments[i + 1] : segment;
+              const nextColor = typeof nextSegment.color === "object" ? rgbToHex(nextSegment.color) : nextSegment.color;
+              return interpolateRgb(color, nextColor)(this._valueToPercentage(numberState, segment.from, nextSegment.from));
+            } else {
+              const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+              return color;
+            }
         }
       }
     }
     return undefined;
   }
 
-  private _renderSegments(segments: SegmentsConfig[]): TemplateResult[] {
+  private _renderSegments(segments: SegmentsConfig[], min: number, max: number): TemplateResult[] {
     if (segments) {
       let sortedSegments = [...segments].sort((a, b) => a.from - b.from);
 
-      return [...sortedSegments].map((segment, index) => {
-        let roundEnd: TemplateResult | undefined;
-        const startAngle = index === 0 ? 0 : this._getAngle(segment.from);
-        const angle = index === sortedSegments.length - 1 ? MAX_ANGLE : this._getAngle(sortedSegments[index + 1].from);
-        const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
-        const segmentPath = svgArc({
-          x: 0,
-          y: 0,
-          start: startAngle,
-          end: angle,
-          r: RADIUS,
+      if (this._config?.smooth_segments) {
+        let gradient: string = "";
+        sortedSegments.map((segment, index) => {
+          const angle = this._getAngle(segment.from, min, max) + 45;
+          const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+          gradient += `${color} ${angle}deg${index != sortedSegments.length - 1 ? "," : ""}`;
         });
-
-        if (index === 0 || index === sortedSegments.length - 1) {
-          const endPath = svgArc({
+        return [svg`
+          <foreignObject x="-50" y="-50" width="100%" height="100%" transform="rotate(45)">
+            <div style="width: 100px; height: 100px; background-image: conic-gradient(${gradient})">
+            </div>
+          </foreignObject>
+        `];
+      } else {
+        return [...sortedSegments].map((segment, index) => {
+          let roundEnd: TemplateResult | undefined;
+          const startAngle = index === 0 ? 0 : this._getAngle(segment.from, min, max);
+          const angle = index === sortedSegments.length - 1 ? MAX_ANGLE : this._getAngle(sortedSegments[index + 1].from, min, max);
+          const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+          const segmentPath = svgArc({
             x: 0,
             y: 0,
-            start: index === 0 ? 0 : MAX_ANGLE,
-            end: index === 0 ? 0 : MAX_ANGLE,
+            start: startAngle,
+            end: angle,
             r: RADIUS,
           });
-          roundEnd = svg`
-          <path
-            class="segment"
-            stroke=${color}
-            d=${endPath}
-            stroke-linecap="round"
-          />`;
-        }
 
-        return svg`${roundEnd}
-          <path
-            class="segment"
-            stroke=${color}
-            d=${segmentPath}
-          />`;
-      });
+          if (index === 0 || index === sortedSegments.length - 1) {
+            const endPath = svgArc({
+              x: 0,
+              y: 0,
+              start: index === 0 ? 0 : MAX_ANGLE,
+              end: index === 0 ? 0 : MAX_ANGLE,
+              r: RADIUS,
+            });
+            roundEnd = svg`
+            <path
+              class="segment"
+              stroke=${color}
+              d=${endPath}
+              stroke-linecap="round"
+            />`;
+          }
+
+          return svg`${roundEnd}
+            <path
+              class="segment"
+              stroke=${color}
+              d=${segmentPath}
+            />`;
+        });
+      }
     }
     return [];
   }
@@ -463,7 +491,7 @@ export class ModernCircularGaugeBadge extends LitElement {
       container-type: normal;
       container-name: container;
       width: calc(var(--ha-badge-size, 36px) - 2px);
-      height: var(--ha-badge-size, 36px);
+      height: calc(var(--ha-badge-size, 36px) - 2px);
       margin-left: -12px;
       margin-inline-start: -12px;
       pointer-events: none;

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -168,9 +168,20 @@ export class ModernCircularGaugeEditor extends LitElement {
         },
       },
       {
-        name: "needle",
-        label: "gauge.needle_gauge",
-        selector: { boolean: {} },
+        name: "",
+        type: "grid",
+        schema: [
+          {
+            name: "needle",
+            label: "gauge.needle_gauge",
+            selector: { boolean: {} },
+          },
+          {
+            name: "smooth_segments",
+            label: "Smooth color segments",
+            selector: { boolean: {} },
+          },
+        ],
       },
       {
         name: "segments",

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -262,6 +262,13 @@ export class ModernCircularGauge extends LitElement {
                   d=${path}
                 />
               </mask>
+              <mask id="gradient-inner-path">
+                <path
+                  class="arc"
+                  stroke="white"
+                  d=${innerPath}
+                />
+              </mask>
             </defs>
             <path
               class="arc clear"
@@ -380,7 +387,7 @@ export class ModernCircularGauge extends LitElement {
       ` : nothing}
       ${needle ? svg`
         ${secondaryObj.segments ? svg`
-        <g class="segments">
+        <g class="segments" mask=${ifDefined(this._config?.smooth_segments ? "url(#gradient-inner-path)" : undefined)}>
           ${this._renderSegments(secondaryObj.segments, min, max, INNER_RADIUS)}
         </g>`
         : nothing

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -854,7 +854,7 @@ export class ModernCircularGauge extends LitElement {
     }
 
     .segments {
-      opacity: 0.3;
+      opacity: 0.35;
     }
 
     .needle {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -14,6 +14,7 @@ import { styleMap } from "lit/directives/style-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { actionHandler } from "../utils/action-handler-directive";
 import { rgbToHex } from "../utils/color";
+import { interpolateRgb } from "d3-interpolate";
 import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS } from "../const";
 import { RenderTemplateResult, subscribeRenderTemplate } from "../ha/ws-templates";
 import { isTemplate } from "../utils/template";
@@ -253,6 +254,15 @@ export class ModernCircularGauge extends LitElement {
           class=${classMap({ "dual-gauge": typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner" })}
         >
           <g transform="rotate(${ROTATE_ANGLE})">
+            <defs>
+              <mask id="gradient-path">
+                <path
+                  class="arc"
+                  stroke="white"
+                  d=${path}
+                />
+              </mask>
+            </defs>
             <path
               class="arc clear"
               d=${path}
@@ -273,7 +283,7 @@ export class ModernCircularGauge extends LitElement {
               : nothing}
             ${needle ? svg`
               ${this._config.segments ? svg`
-              <g class="segments">
+              <g class="segments" mask=${ifDefined(this._config.smooth_segments ? "url(#gradient-path)" : undefined)}>
                 ${this._renderSegments(this._config.segments, min, max, RADIUS)}
               </g>`
               : nothing
@@ -471,43 +481,58 @@ export class ModernCircularGauge extends LitElement {
     if (segments) {
       let sortedSegments = [...segments].sort((a, b) => a.from - b.from);
 
-      return [...sortedSegments].map((segment, index) => {
-        let roundEnd: TemplateResult | undefined;
-        const startAngle = index === 0 ? 0 : this._getAngle(segment.from, min, max);
-        const angle = index === sortedSegments.length - 1 ? MAX_ANGLE : this._getAngle(sortedSegments[index + 1].from, min, max);
-        const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
-        const segmentPath = svgArc({
-          x: 0,
-          y: 0,
-          start: startAngle,
-          end: angle,
-          r: radius,
+      if (this._config?.smooth_segments) {
+        let gradient: string = "";
+        sortedSegments.map((segment, index) => {
+          const angle = this._getAngle(segment.from, min, max) + 45;
+          const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+          gradient += `${color} ${angle}deg${index != sortedSegments.length - 1 ? "," : ""}`;
         });
-
-        if (index === 0 || index === sortedSegments.length - 1) {
-          const endPath = svgArc({
+        return [svg`
+          <foreignObject x="-50" y="-50" width="100%" height="100%" transform="rotate(45)">
+            <div style="width: 100px; height: 100px; background-image: conic-gradient(${gradient})">
+            </div>
+          </foreignObject>
+        `];
+      } else {
+        return [...sortedSegments].map((segment, index) => {
+          let roundEnd: TemplateResult | undefined;
+          const startAngle = index === 0 ? 0 : this._getAngle(segment.from, min, max);
+          const angle = index === sortedSegments.length - 1 ? MAX_ANGLE : this._getAngle(sortedSegments[index + 1].from, min, max);
+          const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+          const segmentPath = svgArc({
             x: 0,
             y: 0,
-            start: index === 0 ? 0 : MAX_ANGLE,
-            end: index === 0 ? 0 : MAX_ANGLE,
+            start: startAngle,
+            end: angle,
             r: radius,
           });
-          roundEnd = svg`
-          <path
-            class="segment"
-            stroke=${color}
-            d=${endPath}
-            stroke-linecap="round"
-          />`;
-        }
-
-        return svg`${roundEnd}
-          <path
-            class="segment"
-            stroke=${color}
-            d=${segmentPath}
-          />`;
-      });
+  
+          if (index === 0 || index === sortedSegments.length - 1) {
+            const endPath = svgArc({
+              x: 0,
+              y: 0,
+              start: index === 0 ? 0 : MAX_ANGLE,
+              end: index === 0 ? 0 : MAX_ANGLE,
+              r: radius,
+            });
+            roundEnd = svg`
+            <path
+              class="segment"
+              stroke=${color}
+              d=${endPath}
+              stroke-linecap="round"
+            />`;
+          }
+  
+          return svg`${roundEnd}
+            <path
+              class="segment"
+              stroke=${color}
+              d=${segmentPath}
+            />`;
+        });
+      }
     }
     return [];
   }
@@ -515,13 +540,20 @@ export class ModernCircularGauge extends LitElement {
   private _computeSegments(numberState: number, segments: SegmentsConfig[] | undefined): string | undefined {
     if (segments) {
       let sortedSegments = [...segments].sort((a, b) => a.from - b.from);
-
+      
       for (let i = 0; i < sortedSegments.length; i++) {
         let segment = sortedSegments[i];
         if (segment && (numberState >= segment.from || i === 0) &&
           (i + 1 == sortedSegments?.length || numberState < sortedSegments![i + 1].from)) {
-            const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
-            return color;
+            if (this._config?.smooth_segments) {
+              const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+              const nextSegment = sortedSegments[i + 1] ? sortedSegments[i + 1] : segment;
+              const nextColor = typeof nextSegment.color === "object" ? rgbToHex(nextSegment.color) : nextSegment.color;
+              return interpolateRgb(color, nextColor)(this._valueToPercentage(numberState, segment.from, nextSegment.from));
+            } else {
+              const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+              return color;
+            }
         }
       }
     }
@@ -816,7 +848,6 @@ export class ModernCircularGauge extends LitElement {
 
     .segments {
       opacity: 0.3;
-      filter: contrast(0.8);
     }
 
     .needle {

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -25,6 +25,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     unit?: string;
     header_position?: "top" | "bottom";
     needle?: boolean;
+    smooth_segments?: boolean;
     segments?: SegmentsConfig[];
     secondary?: SecondaryEntity | string;
     secondary_entity?: SecondaryEntity; // Unused


### PR DESCRIPTION
This introduces smooth color segments option.
![light](https://github.com/user-attachments/assets/aac06251-bdf8-4a87-8d2a-dafe9fe70a38)
![dark](https://github.com/user-attachments/assets/4b4db82a-5fff-402d-9760-21a010e48bed)
Gradient is made using `div` with `conic-gradient` inside `foreignobject`.
Gauge color is interpolated with `d3-interpolate`.
