### PR TITLE
feat: gauge card icon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | type | `string` | 'custom:modern-circular-gauge' |
 | entity | `string` | Required | Entity. May contain templates
 | name | `string` | Optional | Custom title
+| icon | `string` | Optional | Custom icon. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | min | `number` or `string` | `0` | Minimum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | max | `number` or `string` | `100` | Maximum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/) see [example](#gauge-with-templated-additional-info-and-segments)
 | unit | `string` | Optional | Custom unit
@@ -63,8 +64,10 @@ Templates are supported on selected options, configurable only via `yaml`.
 | header_position | `top` or `bottom` | `bottom` | Header position
 | show_state | `boolean` | `true` | Show entity state
 | show_unit | `boolean` | `true` | Show state unit
-| show_header | `boolean` | `true` | Show card header 
+| show_header | `boolean` | `true` | Show card header
+| show_icon | `boolean` | `true` | Show card icon
 | needle | `boolean` | `false` | 
+| adaptive_icon_color | `boolean` | `false` | Makes icon color adaptive to current color segment
 | smooth_segments | `boolean` | `false` | Smooth color segments
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
 | secondary | `object` or `string` | Optional | Secondary info to display under the state, see [secondary entity object](#secondary-entity-object). May contain [templates](https://www.home-assistant.io/docs/configuration/templating/) see [example](#gauge-with-templated-additional-info-and-segments)

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -523,7 +523,7 @@ export class ModernCircularGaugeBadge extends LitElement {
       display: flex;
       flex-direction: column;
       align-items: center;
-      --badge-color: var(--gauge-color)
+      --badge-color: var(--gauge-color);
     }
 
     ha-badge.error {

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -241,6 +241,12 @@ export class ModernCircularGaugeEditor extends LitElement {
             default: true,
             selector: { boolean: {} },
           },
+          {
+            name: "adaptive_icon_color",
+            label: "Adaptive icon color",
+            default: false,
+            selector: { boolean: {} },
+          },
         ],
       },
       {

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -35,16 +35,23 @@ export class ModernCircularGaugeEditor extends LitElement {
     (showInnerGaugeOptions: boolean) =>
     [
       {
-        name: "entity",
-        required: true,
-        selector: { entity: {
-          domain: NUMBER_ENTITY_DOMAINS,
-        }},
-      },
-      {
         name: "",
         type: "grid",
         schema: [
+          {
+            name: "entity",
+            required: true,
+            selector: { entity: {
+              domain: NUMBER_ENTITY_DOMAINS,
+            }},
+          },
+          {
+            name: "icon",
+            selector: { icon: {} },
+            context: {
+              icon_entity: "entity",
+            },
+          },
           {
             name: "name",
             selector: { text: {} },
@@ -225,6 +232,12 @@ export class ModernCircularGaugeEditor extends LitElement {
           {
             name: "show_unit",
             label: "Show unit",
+            default: true,
+            selector: { boolean: {} },
+          },
+          {
+            name: "show_icon",
+            label: "Show icon",
             default: true,
             selector: { boolean: {} },
           },

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -348,7 +348,7 @@ export class ModernCircularGauge extends LitElement {
               class=${classMap({ "adaptive": !!this._config.adaptive_icon_color, "big": !this._hasSecondary })}
               .hass=${this.hass}
               .stateObj=${stateObj}
-              .icon=${this._config.icon}
+              .icon=${this._templateResults?.icon?.result ?? this._config.icon}
             ></ha-state-icon>
           </div>
         </div>
@@ -656,6 +656,7 @@ export class ModernCircularGauge extends LitElement {
   private async _tryConnect(): Promise<void> {
     const templates = {
       entity: this._config?.entity,
+      icon: this._config?.icon,
       min: this._config?.min,
       max: this._config?.max,
       secondary: this._config?.secondary
@@ -732,6 +733,7 @@ export class ModernCircularGauge extends LitElement {
   private async _tryDisconnect(): Promise<void> {
     const templates = {
       entity: this._config?.entity,
+      icon: this._config?.icon,
       min: this._config?.min,
       max: this._config?.max,
       secondary: this._config?.secondary

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -228,11 +228,14 @@ export class ModernCircularGauge extends LitElement {
     const state = templatedState ?? stateObj.state;
     const entityState = formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
+    const iconCenter = !(this._config.show_state ?? false) && (this._config.show_icon ?? true);
+
     return html`
     <ha-card
       class="${classMap({
         "flex-column-reverse": this._config.header_position == "top",
-        "action": this._hasCardAction()
+        "action": this._hasCardAction(),
+        "icon-center": iconCenter
        })}"
       @action=${this._handleAction}
       .actionHandler=${actionHandler({
@@ -316,7 +319,7 @@ export class ModernCircularGauge extends LitElement {
               ` : nothing}
           </g>
         </svg>
-        <svg class="state" viewBox="-50 -50 100 100">
+        <svg class="state" viewBox="-50 ${iconCenter ? -55 : -50} 100 100">
           ${this._config.show_state ? svg`
           <text
             x="0" y="0" 
@@ -923,6 +926,11 @@ export class ModernCircularGauge extends LitElement {
       overflow: hidden;
     }
 
+    .icon-center .icon-wrapper {
+      justify-content: center;
+      align-items: center;
+    }
+
     .icon-wrapper:before {
       display: block;
       content: "";
@@ -939,6 +947,13 @@ export class ModernCircularGauge extends LitElement {
       height: 12%;
       width: 12%;
       --ha-icon-display: flex;
+    }
+
+    .icon-center ha-state-icon, .icon-center ha-state-icon.big {
+      position: static;
+      transform: unset;
+      height: 30%;
+      width: 30%;
     }
 
     ha-state-icon.big {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -917,7 +917,6 @@ export class ModernCircularGauge extends LitElement {
       height: 12%;
       width: 12%;
       --ha-icon-display: flex;
-}
     }
 
     ha-icon {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -315,6 +315,7 @@ export class ModernCircularGauge extends LitElement {
         <div class="icon-container">
           <div class="icon-wrapper">
             <ha-state-icon
+              class=${classMap({ "adaptive": !!this._config.adaptive_icon_color })}
               .hass=${this.hass}
               .stateObj=${stateObj}
               .icon=${this._config.icon}
@@ -913,10 +914,14 @@ export class ModernCircularGauge extends LitElement {
       left: 50%;
       transform: translate(-50%, 0);
       --mdc-icon-size: auto;
-      color: var(--gauge-color);
+      color: var(--primary-color);
       height: 12%;
       width: 12%;
       --ha-icon-display: flex;
+    }
+
+    .adaptive {
+      color: var(--gauge-color);
     }
 
     ha-icon {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -52,6 +52,8 @@ export class ModernCircularGauge extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: ModernCircularGaugeConfig;
 
+  @state() private _hasSecondary?: boolean = false;
+
   @state() private _templateResults?: Partial<Record<string, RenderTemplateResult | undefined>> = {};
 
   @state() private _unsubRenderTemplates?: Map<string, Promise<UnsubscribeFunc>> = new Map();
@@ -314,18 +316,6 @@ export class ModernCircularGauge extends LitElement {
               ` : nothing}
           </g>
         </svg>
-        ${this._config.show_icon ?? true ? html`
-        <div class="icon-container">
-          <div class="icon-wrapper">
-            <ha-state-icon
-              class=${classMap({ "adaptive": !!this._config.adaptive_icon_color })}
-              .hass=${this.hass}
-              .stateObj=${stateObj}
-              .icon=${this._config.icon}
-            ></ha-state-icon>
-          </div>
-        </div>
-        ` : nothing}
         <svg class="state" viewBox="-50 -50 100 100">
           ${this._config.show_state ? svg`
           <text
@@ -351,6 +341,18 @@ export class ModernCircularGauge extends LitElement {
           ` : nothing}
           ${this._renderSecondary()}
         </svg>
+        ${this._config.show_icon ?? true ? html`
+        <div class="icon-container">
+          <div class="icon-wrapper">
+            <ha-state-icon
+              class=${classMap({ "adaptive": !!this._config.adaptive_icon_color, "big": !this._hasSecondary })}
+              .hass=${this.hass}
+              .stateObj=${stateObj}
+              .icon=${this._config.icon}
+            ></ha-state-icon>
+          </div>
+        </div>
+        ` : nothing}
       </div> 
     </ha-card>
     `;
@@ -493,6 +495,7 @@ export class ModernCircularGauge extends LitElement {
     }
 
     if (typeof secondary === "string") {
+      this._hasSecondary = true;
       return svg`
       <text
         x="0" y="0"
@@ -513,6 +516,8 @@ export class ModernCircularGauge extends LitElement {
     if (!stateObj && templatedState === undefined) {
       return svg``;
     }
+
+    this._hasSecondary = true;
 
     const attributes = stateObj?.attributes ?? undefined;
 
@@ -854,6 +859,7 @@ export class ModernCircularGauge extends LitElement {
       left: 0;
       right: 0;
       text-anchor: middle;
+      z-index: 2;
     }
 
     .container {
@@ -901,6 +907,7 @@ export class ModernCircularGauge extends LitElement {
       bottom: 0;
       justify-content: center;
       align-items: center;
+      z-index: 1;
     }
 
     .icon-wrapper {
@@ -930,6 +937,11 @@ export class ModernCircularGauge extends LitElement {
       height: 12%;
       width: 12%;
       --ha-icon-display: flex;
+    }
+
+    ha-state-icon.big {
+      height: 18%;
+      width: 18%;
     }
 
     .adaptive {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -314,6 +314,7 @@ export class ModernCircularGauge extends LitElement {
               ` : nothing}
           </g>
         </svg>
+        ${this._config.show_icon ?? true ? html`
         <div class="icon-container">
           <div class="icon-wrapper">
             <ha-state-icon
@@ -324,6 +325,7 @@ export class ModernCircularGauge extends LitElement {
             ></ha-state-icon>
           </div>
         </div>
+        ` : nothing}
         <svg class="state" viewBox="-50 -50 100 100">
           ${this._config.show_state ? svg`
           <text

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -909,11 +909,15 @@ export class ModernCircularGauge extends LitElement {
 
     ha-state-icon {
       position: absolute;
-      bottom: 7%;
+      bottom: 14%;
       left: 50%;
       transform: translate(-50%, 0);
-      --mdc-icon-size: 16px;
+      --mdc-icon-size: auto;
       color: var(--gauge-color);
+      height: 12%;
+      width: 12%;
+      --ha-icon-display: flex;
+}
     }
 
     ha-icon {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -248,10 +248,11 @@ export class ModernCircularGauge extends LitElement {
           ${this._config.name ?? stateObj.attributes.friendly_name ?? ''}
         </p>
       </div>
-      <div class="container">
+      <div class="container"
+        style=${styleMap({ "--gauge-color": this._computeSegments(numberState, this._config.segments) })}
+      >
         <svg viewBox="-50 -50 100 100" preserveAspectRatio="xMidYMid"
           overflow="visible"
-          style=${styleMap({ "--gauge-color": this._computeSegments(numberState, this._config.segments) })}
           class=${classMap({ "dual-gauge": typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner" })}
         >
           <g transform="rotate(${ROTATE_ANGLE})">
@@ -311,6 +312,15 @@ export class ModernCircularGauge extends LitElement {
               ` : nothing}
           </g>
         </svg>
+        <div class="icon-container">
+          <div class="icon-wrapper">
+            <ha-state-icon
+              .hass=${this.hass}
+              .stateObj=${stateObj}
+              .icon=${this._config.icon}
+            ></ha-state-icon>
+          </div>
+        </div>
         <svg class="state" viewBox="-50 -50 100 100">
           <text
             x="0" y="0" 
@@ -867,6 +877,48 @@ export class ModernCircularGauge extends LitElement {
 
     .secondary.dual-state .unit {
       opacity: 1;
+    }
+
+    .icon-container {
+      display: flex;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .icon-wrapper {
+      position: relative;
+      display: flex;
+      width: 100%;
+      height: auto;
+      max-height: 100%;
+      padding: 0;
+      margin: 0;
+      overflow: hidden;
+    }
+
+    .icon-wrapper:before {
+      display: block;
+      content: "";
+      padding-top: 100%;
+    }
+
+    ha-state-icon {
+      position: absolute;
+      bottom: 7%;
+      left: 50%;
+      transform: translate(-50%, 0);
+      --mdc-icon-size: 16px;
+      color: var(--gauge-color);
+    }
+
+    ha-icon {
+      display: flex;
+      justify-content: center;
     }
 
     .name {

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -33,6 +33,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     show_state?: boolean;
     show_header?: boolean;
     show_unit?: boolean;
+    show_icon?: boolean;
     needle?: boolean;
     adaptive_icon_color?: boolean;
     smooth_segments?: boolean;

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -29,6 +29,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     label?: string;
     header_position?: "top" | "bottom";
     needle?: boolean;
+    adaptive_icon_color?: boolean;
     smooth_segments?: boolean;
     segments?: SegmentsConfig[];
     secondary?: SecondaryEntity | string;

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -22,6 +22,7 @@ export type SecondaryEntity = {
 export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     entity: string;
     name?: string;
+    icon?: string;
     min?: number | string;
     max?: number | string;
     unit?: string;


### PR DESCRIPTION
This adds small icon displayed on the bottom of the gauge. It has two sizes depending on the card configuration.
Icon can be defined with templates or with just a icon name.
By default, icon uses the same one as the defined entity.
If color segments are defined, icon can inherit current segments color.
Icon automatically moves to the center when the entity state is hidden.

![cards](https://github.com/user-attachments/assets/24b44179-b202-440b-8212-fd8161bbc388)


![cards_center](https://github.com/user-attachments/assets/ac77962c-c750-487d-a3aa-7f5ec23028d3)

