### PR TITLE
feat: custom gauge scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_header | `boolean` | `true` | Show card header 
 | needle | `boolean` | `false` | 
 | smooth_segments | `boolean` | `false` | Smooth color segments
+| state_font_size | `number` | `24` | Initial state size in px
+| gauge_width | `number` | `6` | Gauge width
+| state_scaling_limit | `number` | `7` | Max state length without scaling
+| state_scaling_multiplier | `number` | `1` | State scaling multiplier
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
 | secondary | `object` or `string` | Optional | Secondary info to display under the state, see [secondary entity object](#secondary-entity-object). May contain [templates](https://www.home-assistant.io/docs/configuration/templating/) see [example](#gauge-with-templated-additional-info-and-segments)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | needle | `boolean` | `false` | 
 | smooth_segments | `boolean` | `false` | Smooth color segments
 | state_font_size | `number` | `24` | Initial state size in px
+| header_font_size | `number` | `14` | Gauge header font size in px
 | gauge_width | `number` | `6` | Gauge width
 | state_scaling_limit | `number` | `7` | Max state length without scaling
 | state_scaling_multiplier | `number` | `1` | State scaling multiplier

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -251,7 +251,8 @@ export class ModernCircularGauge extends LitElement {
       <div class="container">
         <svg viewBox="-50 -50 100 100" preserveAspectRatio="xMidYMid"
           overflow="visible"
-          style=${styleMap({ "--gauge-color": this._computeSegments(numberState, this._config.segments) })}
+          style=${styleMap({ "--gauge-color": this._computeSegments(numberState, this._config.segments),
+            "--gauge-stroke-width": this._config.gauge_width ? `${this._config.gauge_width}px` : undefined })}
           class=${classMap({ "dual-gauge": typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner" })}
         >
           <g transform="rotate(${ROTATE_ANGLE})">
@@ -311,7 +312,7 @@ export class ModernCircularGauge extends LitElement {
               ` : nothing}
           </g>
         </svg>
-        <svg class="state" viewBox="-50 -50 100 100">
+        <svg class="state" overflow="visible" viewBox="-50 -50 100 100">
           <text
             x="0" y="0" 
             class="value ${classMap({"dual-state": typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big"})}" 
@@ -340,14 +341,14 @@ export class ModernCircularGauge extends LitElement {
   }
 
   private _calcStateSize(state: string): string {
-    let initialSize = 24;
+    let initialSize = this._config?.state_size ?? 24;
     if (typeof this._config?.secondary != "string") {
       initialSize -= this._config?.secondary?.show_gauge == "inner" ? 2 : 0;
       initialSize -= this._config?.secondary?.state_size == "big" ? 3 : 0;
     }
 
-    if (state.length >= 7) {
-      return `${initialSize - (state.length - 4)}px`
+    if (state.length >= (this._config?.state_scaling_limit ?? 7)) {
+      return `${initialSize - (state.length - 4) * (this._config?.state_scaling_multiplier ?? 1)}px`
     }
     return `${initialSize}px`;
   }

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -244,7 +244,7 @@ export class ModernCircularGauge extends LitElement {
       )}
     >
       ${this._config.show_header ? html`
-      <div class="header">
+      <div class="header" style=${styleMap({ "--gauge-header-font-size": this._config.header_font_size ? `${this._config.header_font_size}px` : undefined })}>
         <p class="name">
           ${this._config.name ?? stateObj.attributes.friendly_name ?? ''}
         </p>
@@ -802,6 +802,7 @@ export class ModernCircularGauge extends LitElement {
     :host {
       --gauge-color: var(--primary-color);
       --gauge-stroke-width: 6px;
+      --gauge-header-font-size: 14px;
     }
 
     ha-card {
@@ -882,7 +883,7 @@ export class ModernCircularGauge extends LitElement {
 
     .name {
       width: 100%;
-      font-size: 14px;
+      font-size: var(--gauge-header-font-size);
       margin: 0;
       white-space: nowrap;
       overflow: hidden;

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -345,7 +345,7 @@ export class ModernCircularGauge extends LitElement {
   }
 
   private _calcStateSize(state: string): string {
-    let initialSize = this._config?.state_size ?? 24;
+    let initialSize = this._config?.state_font_size ?? 24;
     if (typeof this._config?.secondary != "string") {
       initialSize -= this._config?.secondary?.show_gauge == "inner" ? 2 : 0;
       initialSize -= this._config?.secondary?.state_size == "big" ? 3 : 0;

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -958,7 +958,7 @@ export class ModernCircularGauge extends LitElement {
     .dot {
       fill: none;
       stroke-linecap: round;
-      stroke-width: 3px;
+      stroke-width: calc(var(--gauge-stroke-width) / 2);
       stroke: var(--primary-text-color);
       transition: all 1s ease 0s;
       opacity: 0.5;

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -34,7 +34,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     show_unit?: boolean;
     needle?: boolean;
     smooth_segments?: boolean;
-    state_size?: number;
+    state_font_size?: number;
     gauge_width?: number;
     state_scaling_limit?: number;
     state_scaling_multiplier?: number;

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -35,6 +35,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     needle?: boolean;
     smooth_segments?: boolean;
     state_font_size?: number;
+    header_font_size?: number;
     gauge_width?: number;
     state_scaling_limit?: number;
     state_scaling_multiplier?: number;

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -29,6 +29,10 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     header_position?: "top" | "bottom";
     needle?: boolean;
     smooth_segments?: boolean;
+    state_size?: number;
+    gauge_width?: number;
+    state_scaling_limit?: number;
+    state_scaling_multiplier?: number;
     segments?: SegmentsConfig[];
     secondary?: SecondaryEntity | string;
     secondary_entity?: SecondaryEntity; // Unused


### PR DESCRIPTION
This allows to define custom gauge size for better customization. Useful when having multiple cards in the same row resulting in small card elements.