### PR TITLE
fix: improve gauge visibility

### DIFF
--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -291,7 +291,7 @@ export class ModernCircularGaugeBadge extends LitElement {
                   stroke="white"
                   d=${path}
                 />
-                <circle cx="42" cy="0" r="12" fill="black" transform="rotate(${this._getAngle(numberState, min, max)})"/>
+                <circle cx="42" cy="0" r="14" fill="black" transform="rotate(${this._getAngle(numberState, min, max)})"/>
               </mask>
               ` : nothing}
             </defs>
@@ -514,7 +514,7 @@ export class ModernCircularGaugeBadge extends LitElement {
     }
 
     .segments {
-      opacity: 0.35;
+      opacity: 0.45;
     }
 
     ha-badge {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -1084,7 +1084,7 @@ export class ModernCircularGauge extends LitElement {
       stroke-width: 3px;
       stroke: var(--primary-text-color);
       transition: all 1s ease 0s;
-      opacity: 0.8;
+      opacity: 0.9;
     }
     .dot-border {
       fill: none;
@@ -1092,7 +1092,7 @@ export class ModernCircularGauge extends LitElement {
       stroke-width: calc(var(--gauge-stroke-width) - 1px);
       stroke: var(--primary-background-color);
       transition: all 1s ease 0s;
-      opacity: 0.5;
+      opacity: 0.6;
     }
     `;
   }

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -262,18 +262,33 @@ export class ModernCircularGauge extends LitElement {
                   stroke="white"
                   d=${path}
                 />
-              </mask>
-              <mask id="gradient-inner-path">
+                ${needle ? svg`
                 <path
-                  class="arc"
-                  stroke="white"
-                  d=${innerPath}
+                  class="needle-border"
+                  d=${path}
+                  stroke-dasharray="${needle[0]}"
+                  stroke-dashoffset="${needle[1]}"
+                  stroke="black"
                 />
+                ` : nothing}
+              </mask>
+              <mask id="needle-mask">
+                <rect x="-50" y="-50" width="100" height="100" fill="white"/>
+                ${needle ? svg`
+                <path
+                  class="needle-border"
+                  d=${path}
+                  stroke-dasharray="${needle[0]}"
+                  stroke-dashoffset="${needle[1]}"
+                  stroke="black"
+                />
+                ` : nothing}
               </mask>
             </defs>
             <path
               class="arc clear"
               d=${path}
+              mask=${ifDefined(needle ? "url(#needle-mask)" : undefined)}
             />
             ${current ? svg`
               <path
@@ -291,17 +306,11 @@ export class ModernCircularGauge extends LitElement {
               : nothing}
             ${needle ? svg`
               ${this._config.segments ? svg`
-              <g class="segments" mask=${ifDefined(this._config.smooth_segments ? "url(#gradient-path)" : undefined)}>
+              <g class="segments" mask=${ifDefined(this._config.smooth_segments ? "url(#gradient-path)" : "url(#needle-mask)")}>
                 ${this._renderSegments(this._config.segments, min, max, RADIUS)}
               </g>`
               : nothing
               }
-              <path
-                class="needle-border"
-                d=${path}
-                stroke-dasharray="${needle[0]}"
-                stroke-dashoffset="${needle[1]}"
-              />
               <path
                 class="needle"
                 d=${path}
@@ -389,9 +398,38 @@ export class ModernCircularGauge extends LitElement {
       class="inner"
       style=${styleMap({ "--gauge-color": this._computeSegments(numberState, secondaryObj.segments) })}
       >
+      <mask id="gradient-inner-path">
+        <path
+          class="arc"
+          stroke="white"
+          d=${innerPath}
+        />
+        ${needle ? svg`
+        <path
+          class="needle-border"
+          d=${innerPath}
+          stroke-dasharray="${needle[0]}"
+          stroke-dashoffset="${needle[1]}"
+          stroke="black"
+        />
+        ` : nothing}
+      </mask>
+      <mask id="inner-needle-mask">
+        <rect x="-50" y="-50" width="100" height="100" fill="white"/>
+        ${needle ? svg`
+        <path
+          class="needle-border"
+          d=${innerPath}
+          stroke-dasharray="${needle[0]}"
+          stroke-dashoffset="${needle[1]}"
+          stroke="black"
+        />
+        ` : nothing}
+      </mask>
       <path
         class="arc clear"
         d=${innerPath}
+        mask=${ifDefined(needle ? "url(#gradient-inner-path)" : undefined)}
       />
       ${current ? svg`
         <path
@@ -404,17 +442,11 @@ export class ModernCircularGauge extends LitElement {
       ` : nothing}
       ${needle ? svg`
         ${secondaryObj.segments ? svg`
-        <g class="segments" mask=${ifDefined(this._config?.smooth_segments ? "url(#gradient-inner-path)" : undefined)}>
+        <g class="segments" mask=${ifDefined(this._config?.smooth_segments ? "url(#gradient-inner-path)" : "url(#inner-needle-mask)")}>
           ${this._renderSegments(secondaryObj.segments, min, max, INNER_RADIUS)}
         </g>`
         : nothing
         }
-        <path
-          class="needle-border"
-          d=${innerPath}
-          stroke-dasharray="${needle[0]}"
-          stroke-dashoffset="${needle[1]}"
-        />
         <path
           class="needle"
           d=${innerPath}
@@ -912,7 +944,7 @@ export class ModernCircularGauge extends LitElement {
     }
 
     .segments {
-      opacity: 0.35;
+      opacity: 0.45;
     }
 
     .needle {
@@ -926,8 +958,7 @@ export class ModernCircularGauge extends LitElement {
     .needle-border {
       fill: none;
       stroke-linecap: round;
-      stroke-width: calc(var(--gauge-stroke-width) + 3px);
-      stroke: var(--card-background-color);
+      stroke-width: calc(var(--gauge-stroke-width) + 4px);
       transition: all 1s ease 0s, stroke 0.3s ease-out;
     }
 
@@ -940,7 +971,7 @@ export class ModernCircularGauge extends LitElement {
     }
 
     .dual-gauge .needle-border {
-      stroke-width: calc(var(--gauge-stroke-width) + 2px);
+      stroke-width: calc(var(--gauge-stroke-width) + 3px);
     }
 
     .dot {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -410,11 +410,6 @@ export class ModernCircularGauge extends LitElement {
         : nothing
         }
         <path
-          d=${innerPath}
-          stroke-dasharray="${needle[0]}"
-          stroke-dashoffset="${needle[1]}"
-        />
-        <path
           class="needle-border"
           d=${innerPath}
           stroke-dasharray="${needle[0]}"
@@ -931,7 +926,7 @@ export class ModernCircularGauge extends LitElement {
     .needle-border {
       fill: none;
       stroke-linecap: round;
-      stroke-width: calc(var(--gauge-stroke-width) + 2px);
+      stroke-width: calc(var(--gauge-stroke-width) + 3px);
       stroke: var(--card-background-color);
       transition: all 1s ease 0s, stroke 0.3s ease-out;
     }
@@ -942,6 +937,10 @@ export class ModernCircularGauge extends LitElement {
 
     .dual-gauge {
       --gauge-stroke-width: 4px;
+    }
+
+    .dual-gauge .needle-border {
+      stroke-width: calc(var(--gauge-stroke-width) + 2px);
     }
 
     .dot {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -307,18 +307,16 @@ export class ModernCircularGauge extends LitElement {
                 stroke-dashoffset="${current[1]}"
               />
             ` : nothing}
+            ${needle && this._config.segments ? svg`
+            <g class="segments" mask=${ifDefined(this._config.smooth_segments ? "url(#gradient-path)" : "url(#needle-mask)")}>
+              ${this._renderSegments(this._config.segments, min, max, RADIUS)}
+            </g>` : nothing}
             ${typeof this._config.secondary != "string" ? 
               this._config.secondary?.show_gauge == "outter" ? this._renderOutterSecondary()
               : this._config.secondary?.show_gauge == "inner" ? this._renderInnerGauge()
               : nothing
               : nothing}
             ${needle ? svg`
-              ${this._config.segments ? svg`
-              <g class="segments" mask=${ifDefined(this._config.smooth_segments ? "url(#gradient-path)" : "url(#needle-mask)")}>
-                ${this._renderSegments(this._config.segments, min, max, RADIUS)}
-              </g>`
-              : nothing
-              }
               <path
                 class="needle"
                 d=${path}
@@ -509,9 +507,14 @@ export class ModernCircularGauge extends LitElement {
 
     return svg`
     <path
+      class="dot-border"
+      d=${path}
+      stroke-dasharray="${current[0]}"
+      stroke-dashoffset="${current[1]}"
+    />
+    <path
       class="dot"
       d=${path}
-      style=${styleMap({ "opacity": numberState <= mainNumberState ? 0.8 : 0.5 })}
       stroke-dasharray="${current[0]}"
       stroke-dashoffset="${current[1]}"
     />
@@ -1080,6 +1083,14 @@ export class ModernCircularGauge extends LitElement {
       stroke-linecap: round;
       stroke-width: 3px;
       stroke: var(--primary-text-color);
+      transition: all 1s ease 0s;
+      opacity: 0.8;
+    }
+    .dot-border {
+      fill: none;
+      stroke-linecap: round;
+      stroke-width: calc(var(--gauge-stroke-width) - 1px);
+      stroke: var(--primary-background-color);
       transition: all 1s ease 0s;
       opacity: 0.5;
     }

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -282,7 +282,7 @@ export class ModernCircularGauge extends LitElement {
                 ` : nothing}
               </mask>
               <mask id="needle-mask">
-                <rect x="-50" y="-50" width="100" height="100" fill="white"/>
+                <rect x="-60" y="-60" width="120" height="120" fill="white"/>
                 ${needle ? svg`
                 <path
                   class="needle-border"
@@ -436,7 +436,7 @@ export class ModernCircularGauge extends LitElement {
         ` : nothing}
       </mask>
       <mask id="inner-needle-mask">
-        <rect x="-50" y="-50" width="100" height="100" fill="white"/>
+        <rect x="-60" y="-60" width="120" height="120" fill="white"/>
         ${needle ? svg`
         <path
           class="needle-border"


### PR DESCRIPTION
Improves needle and secondary dot visibility.

Needle border size is increased and added support for transparent card background.

Increased secondary dot opacity and added border around it to improve visibility on color segments.

Before:
![before](https://github.com/user-attachments/assets/2f599c7b-fcaf-465b-a86e-8fc947abcd42)

After:
![after](https://github.com/user-attachments/assets/32c0aecd-5847-4802-a9ae-50846866286f)