### PR TITLE
feat: adaptive state color

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_icon | `boolean` | `true` | Show card icon
 | needle | `boolean` | `false` | 
 | adaptive_icon_color | `boolean` | `false` | Makes icon color adaptive to current color segment
+| adaptive_state_color | `boolean` | `false` | Makes state color adaptive to current color segment
 | smooth_segments | `boolean` | `false` | Smooth color segments
 | state_font_size | `number` | `24` | Initial state size in px
 | header_font_size | `number` | `14` | Gauge header font size in px
@@ -114,7 +115,8 @@ Templates are supported on selected options, configurable only via `yaml`.
 | state_size | `small` or `big` | `small` | Secondary state size 
 | show_state | `boolean` | `true` | Show secondary state
 | show_unit | `boolean` | `true` | Show secondary unit
-| needle | `boolean` | `false` |
+| needle | `boolean` | `false` | Makes state color adaptive to current color segment based on `show_gauge` config
+| adaptive_state_color | `boolean` | `false` | 
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
 
 ## Examples

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -159,6 +159,12 @@ export class ModernCircularGaugeEditor extends LitElement {
                 default: true,
                 selector: { boolean: {} },
               },
+              {
+                name: "adaptive_state_color",
+                label: "Adaptive state color",
+                default: false,
+                selector: { boolean: {} },
+              },
             ],
           },
           {
@@ -248,6 +254,12 @@ export class ModernCircularGaugeEditor extends LitElement {
           {
             name: "adaptive_icon_color",
             label: "Adaptive icon color",
+            default: false,
+            selector: { boolean: {} },
+          },
+          {
+            name: "adaptive_state_color",
+            label: "Adaptive state color",
             default: false,
             selector: { boolean: {} },
           },

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -324,7 +324,7 @@ export class ModernCircularGauge extends LitElement {
           ${this._config.show_state ? svg`
           <text
             x="0" y="0" 
-            class="value ${classMap({"dual-state": typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big"})}" 
+            class="value ${classMap({"dual-state": typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big", "adaptive": !!this._config.adaptive_state_color})}" 
             style=${styleMap({ "font-size": this._calcStateSize(entityState) })}
             dy=${typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big" ? -14 : 0}
           >
@@ -530,6 +530,16 @@ export class ModernCircularGauge extends LitElement {
     const state = templatedState ?? stateObj.state;
     const entityState = formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
+    let secondaryColor;
+
+    if (secondary.adaptive_state_color) {
+      if (secondary.show_gauge == "outter") {
+        secondaryColor = this._computeSegments(Number(state), this._config?.segments);
+      } else if (secondary.show_gauge == "inner") {
+        secondaryColor = this._computeSegments(Number(state), secondary.segments);
+      }
+    }
+
     return svg`
     <text
       @action=${this._handleSecondaryAction}
@@ -537,8 +547,10 @@ export class ModernCircularGauge extends LitElement {
         hasHold: hasAction(secondary.hold_action),
         hasDoubleClick: hasAction(secondary.double_tap_action),
       })}
-      class="secondary ${classMap({"dual-state": secondary.state_size == "big"})}"
-      style=${styleMap({ "font-size": secondary.state_size == "big" ? this._calcStateSize(entityState) : undefined })}
+      class="secondary ${classMap({ "dual-state": secondary.state_size == "big", "adaptive": !!secondary.adaptive_state_color })}"
+      style=${styleMap({ "font-size": secondary.state_size == "big" ? this._calcStateSize(entityState) : undefined,
+        "fill": secondaryColor ?? undefined
+       })}
       dy=${secondary.state_size == "big" ? 14 : 20}
     >
       ${entityState}
@@ -979,6 +991,10 @@ export class ModernCircularGauge extends LitElement {
 
     .adaptive {
       color: var(--gauge-color);
+    }
+
+    .value.adaptive, .secondary.adaptive {
+      fill: var(--gauge-color);
     }
 
     ha-icon {

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -18,6 +18,7 @@ export type SecondaryEntity = {
     show_state?: boolean;
     show_unit?: boolean;
     needle?: boolean;
+    adaptive_state_color?: boolean;
     segments?: SegmentsConfig[];
     [key: string]: any;
 };
@@ -37,6 +38,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     show_icon?: boolean;
     needle?: boolean;
     adaptive_icon_color?: boolean;
+    adaptive_state_color?: boolean;
     smooth_segments?: boolean;
     state_font_size?: number;
     header_font_size?: number;


### PR DESCRIPTION
This adds adaptive color for state.
Adaptive state color is supported both for main state and secondary state.

Secondary state color depends on `show_gauge` for selecting which color to use:
`none`: secondary state color is the same as the main one
![brave_Uid2Ieb0os](https://github.com/user-attachments/assets/39903414-7b1b-4e39-83f6-55d10bbe194a)

`inner`: secondary state uses secondary color segments
![brave_6PGxr5p7mf](https://github.com/user-attachments/assets/32378614-6b25-402e-867c-996c3e8d9b59)

`outter`: secondary state uses primary color segments
![card](https://github.com/user-attachments/assets/9ab91d1d-0983-49ac-b34e-582e10a96a52)
