### PR TITLE
feat: expanded template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern look at the default Home Assistant gauge card
 - Secondary info under the state with two size options
 - Sections support
 - Needle
-- Template support for `min`, `max`, `entity`, `icon` and `secondary` (YAML only)
+- Template support for `min`, `max`, `entity`, `name`, `icon` and `secondary` (YAML only)
 - Color segments with gradient
 - Dual gauge
 - Dual value representing as a dot on the same gauge
@@ -55,7 +55,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 |------|:----:|:-------:|:------------|
 | type | `string` | 'custom:modern-circular-gauge' |
 | entity | `string` | Required | Entity. May contain templates
-| name | `string` | Optional | Custom title
+| name | `string` | Optional | Custom title. May contain templates
 | icon | `string` | Optional | Custom icon. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | min | `number` or `string` | `0` | Minimum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | max | `number` or `string` | `100` | Maximum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/) see [example](#gauge-with-templated-additional-info-and-segments)
@@ -83,8 +83,8 @@ Templates are supported on selected options, configurable only via `yaml`.
 |------|:----:|:-------:|:------------|
 | type | `string` | 'custom:modern-circular-gauge-badge' |
 | entity | `string` | Required | Entity. May contain templates.
-| name | `string` | Optional | Custom title
-| icon | `string` | Entity icon | Custom icon
+| name | `string` | Optional | Custom title. May contain templates
+| icon | `string` | Entity icon | Custom icon. May contain templates
 | min | `number` or `string` | `0` | Minimum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | max | `number` or `string` | `100` | Maximum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | unit | `string` | Optional | Custom unit

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -251,7 +251,7 @@ export class ModernCircularGauge extends LitElement {
       ${this._config.show_header ? html`
       <div class="header" style=${styleMap({ "--gauge-header-font-size": this._config.header_font_size ? `${this._config.header_font_size}px` : undefined })}>
         <p class="name">
-          ${this._config.name ?? stateObj.attributes.friendly_name ?? ''}
+          ${this._templateResults?.name?.result ?? this._config.name ?? stateObj.attributes.friendly_name ?? ''}
         </p>
       </div>
       ` : nothing}
@@ -664,6 +664,7 @@ export class ModernCircularGauge extends LitElement {
   private async _tryConnect(): Promise<void> {
     const templates = {
       entity: this._config?.entity,
+      name: this._config?.name,
       icon: this._config?.icon,
       min: this._config?.min,
       max: this._config?.max,
@@ -741,6 +742,7 @@ export class ModernCircularGauge extends LitElement {
   private async _tryDisconnect(): Promise<void> {
     const templates = {
       entity: this._config?.entity,
+      name: this._config?.name,
       icon: this._config?.icon,
       min: this._config?.min,
       max: this._config?.max,


### PR DESCRIPTION
This adds additional config template support.
For badge:
- `name`
- `icon`

For card:
- `name`