### PR TITLE
feat: inner gauge width config

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | state_size | `small` or `big` | `small` | Secondary state size 
 | show_state | `boolean` | `true` | Show secondary state
 | show_unit | `boolean` | `true` | Show secondary unit
+| gauge_width | `number` | `4` | Inner gauge width
 | needle | `boolean` | `false` |
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
 

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -260,7 +260,9 @@ export class ModernCircularGauge extends LitElement {
       >
         <svg viewBox="-50 -50 100 100" preserveAspectRatio="xMidYMid"
           overflow="visible"
-          style=${styleMap({ "--gauge-stroke-width": this._config.gauge_width ? `${this._config.gauge_width}px` : undefined })}
+          style=${styleMap({ "--gauge-stroke-width": this._config.gauge_width ? `${this._config.gauge_width}px` : undefined,
+            "--inner-gauge-stroke-width": typeof this._config.secondary == "object" ? this._config.secondary?.gauge_width ? `${this._config.secondary?.gauge_width}px` : undefined : undefined })}
+           })}
           class=${classMap({ "dual-gauge": typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner" })}
         >
           <g transform="rotate(${ROTATE_ANGLE})">
@@ -275,6 +277,7 @@ export class ModernCircularGauge extends LitElement {
               <mask id="gradient-inner-path">
                 <path
                   class="arc"
+                  style="stroke-width: var(--inner-gauge-stroke-width)"
                   stroke="white"
                   d=${innerPath}
                 />
@@ -839,6 +842,7 @@ export class ModernCircularGauge extends LitElement {
     :host {
       --gauge-color: var(--primary-color);
       --gauge-stroke-width: 6px;
+      --inner-gauge-stroke-width: 4px;
       --gauge-header-font-size: 14px;
     }
 
@@ -1055,6 +1059,7 @@ export class ModernCircularGauge extends LitElement {
 
     .inner {
       --gauge-color: var(--accent-color);
+      --gauge-stroke-width: var(--inner-gauge-stroke-width);
     }
 
     .dual-gauge {

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -18,6 +18,7 @@ export type SecondaryEntity = {
     show_state?: boolean;
     show_unit?: boolean;
     needle?: boolean;
+    gauge_width?: number;
     segments?: SegmentsConfig[];
     [key: string]: any;
 };


### PR DESCRIPTION
Separates `gauge_width` for inner and outter gauge, allowing having two different gauge width options.
![gauge](https://github.com/user-attachments/assets/a67b0add-c186-47ce-848a-bd1db1b877f3)
