### PR TITLE
fix: automatic color conversion from hex to color list

### DIFF
--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -316,13 +316,6 @@ export class ModernCircularGaugeEditor extends LitElement {
 
     const DATA = {
       ...this._config,
-      segments: this._config.segments?.map(value => {
-        let color = value.color;
-        if (typeof value.color === "string") {
-          color = hexToRgb(value.color) as any;
-        }
-        return { ...value, color };
-      })
     };
 
     return html`


### PR DESCRIPTION
Removes automatic color conversion for visual editor.

Color conversion was automatic and because of that, colors encoded in hex were converted to color list format every time the UI editor was opened. One drawback is, the color selector in editor will appear black when color is in hex format.