### PR TITLE
feat: state display override

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_header | `boolean` | `true` | Show card header
 | show_icon | `boolean` | `true` | Show card icon
 | needle | `boolean` | `false` | 
+| state_text | `string` | Entity state | Displayed state override. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | adaptive_icon_color | `boolean` | `false` | Makes icon color adaptive to current color segment
 | adaptive_state_color | `boolean` | `false` | Makes state color adaptive to current color segment
 | smooth_segments | `boolean` | `false` | Smooth color segments
@@ -95,6 +96,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_state | `bool` | `true` | Show entity state
 | show_icon | `bool` | `false` | Show icon
 | needle | `bool` | `false` | 
+| state_text | `string` | Entity state | Displayed state override. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | smooth_segments | `boolean` | `false` | Smooth color segments
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
 

--- a/src/badge/gauge-badge-config.ts
+++ b/src/badge/gauge-badge-config.ts
@@ -12,6 +12,7 @@ export interface ModernCircularGaugeBadgeConfig extends LovelaceBadgeConfig {
   show_state?: boolean;
   show_icon?: boolean;
   needle?: boolean;
+  state_text?: string;
   smooth_segments?: boolean;
   segments?: SegmentsConfig[];
 }

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -96,6 +96,7 @@ export class ModernCircularGaugeBadge extends LitElement {
       min: this._config?.min,
       max: this._config?.max,
       segments: this._config?.segments,
+      stateText: this._config?.state_text,
     };
 
     Object.entries(templates).forEach(([key, value]) => {
@@ -162,6 +163,7 @@ export class ModernCircularGaugeBadge extends LitElement {
       min: this._config?.min,
       max: this._config?.max,
       segments: this._config?.segments,
+      stateText: this._config?.state_text,
     };
     
     Object.entries(templates).forEach(([key, _]) => {
@@ -247,11 +249,14 @@ export class ModernCircularGaugeBadge extends LitElement {
 
     const numberState = Number(templatedState ?? stateObj.state);
 
-    const unit = (this._config.unit ?? stateObj?.attributes.unit_of_measurement) || "";
-
+    
     const current = this._config.needle ? undefined : strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0, min, max, RADIUS);
     const state = templatedState ?? stateObj.state;
-    const entityState = formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
+
+    const stateOverride = this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : this._config.state_text);
+    const unit = stateOverride ? "" : (this._config.unit ?? stateObj?.attributes.unit_of_measurement) || "";
+
+    const entityState = stateOverride ?? formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
     const name = this._templateResults?.name?.result ?? this._config.name ?? stateObj?.attributes.friendly_name ?? "";
     const label = this._config.show_name && this._config.show_icon && this._config.show_state ? name : undefined;

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -216,7 +216,8 @@ export class ModernCircularGauge extends LitElement {
     const needle = this._config.needle ? strokeDashArc(numberState, numberState, min, max, RADIUS) : undefined;
 
     const state = templatedState ?? stateObj.state;
-    const entityState = formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
+    const stateOverride = this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : this._config.state_text);
+    const entityState = stateOverride ?? formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
     const iconCenter = !(this._config.show_state ?? false) && (this._config.show_icon ?? true);
     const segments = (this._templateResults?.segments?.result as unknown) as SegmentsConfig[] ?? this._config.segments;
@@ -308,7 +309,7 @@ export class ModernCircularGauge extends LitElement {
             dy=${typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big" ? -14 : 0}
           >
             ${this._getSegmentLabel(numberState, segments) ? this._getSegmentLabel(numberState, segments) : svg`
-              ${this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : this._config.state_text) ?? entityState}
+              ${entityState}
               ${(this._config.show_unit ?? true) && !this._config.state_text ? svg`<tspan class="unit" dx="-4" dy="-6">${unit}</tspan>` : nothing}
             `}
           </text>
@@ -483,7 +484,8 @@ export class ModernCircularGauge extends LitElement {
     const unit = secondary.unit ?? attributes?.unit_of_measurement;
 
     const state = templatedState ?? stateObj.state;
-    const entityState = formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
+    const stateOverride = this._templateResults?.secondaryStateText?.result ?? (isTemplate(String(secondary.state_text)) ? "" : secondary.state_text);
+    const entityState = stateOverride ?? formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
     let secondaryColor;
 
@@ -508,7 +510,7 @@ export class ModernCircularGauge extends LitElement {
        })}
       dy=${secondary.state_size == "big" ? 14 : 20}
     >
-      ${this._templateResults?.secondaryStateText?.result ?? (isTemplate(String(secondary.state_text)) ? "" : secondary.state_text) ?? entityState}
+      ${entityState}
       ${(secondary.show_unit ?? true) && !secondary.state_text ? svg`
       <tspan
         class=${classMap({"unit": secondary.state_size == "big"})}
@@ -641,6 +643,7 @@ export class ModernCircularGauge extends LitElement {
       min: this._config?.min,
       max: this._config?.max,
       segments: this._config?.segments,
+      stateText: this._config?.state_text,
       secondary: this._config?.secondary
     };
     
@@ -654,6 +657,7 @@ export class ModernCircularGauge extends LitElement {
         secondaryMin: secondary?.min,
         secondaryMax: secondary?.max,
         secondaryEntity: secondary?.entity,
+        secondaryStateText: secondary?.state_text,
         secondarySegments: secondary?.segments
       };
 

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -308,8 +308,8 @@ export class ModernCircularGauge extends LitElement {
             dy=${typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big" ? -14 : 0}
           >
             ${this._getSegmentLabel(numberState, segments) ? this._getSegmentLabel(numberState, segments) : svg`
-              ${entityState}
-              ${this._config.show_unit ?? true ? svg`<tspan class="unit" dx="-4" dy="-6">${unit}</tspan>` : nothing}
+              ${this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : this._config.state_text) ?? entityState}
+              ${(this._config.show_unit ?? true) && !this._config.state_text ? svg`<tspan class="unit" dx="-4" dy="-6">${unit}</tspan>` : nothing}
             `}
           </text>
           ${typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big"
@@ -508,8 +508,8 @@ export class ModernCircularGauge extends LitElement {
        })}
       dy=${secondary.state_size == "big" ? 14 : 20}
     >
-      ${entityState}
-      ${secondary.show_unit ?? true ? svg`
+      ${this._templateResults?.secondaryStateText?.result ?? (isTemplate(String(secondary.state_text)) ? "" : secondary.state_text) ?? entityState}
+      ${(secondary.show_unit ?? true) && !secondary.state_text ? svg`
       <tspan
         class=${classMap({"unit": secondary.state_size == "big"})}
         dx=${secondary.state_size == "big" ? -4 : 0}
@@ -553,6 +553,7 @@ export class ModernCircularGauge extends LitElement {
       min: this._config?.min,
       max: this._config?.max,
       segments: this._config?.segments,
+      stateText: this._config?.state_text,
       secondary: this._config?.secondary
     };
     
@@ -571,6 +572,7 @@ export class ModernCircularGauge extends LitElement {
         secondaryMin: secondary?.min,
         secondaryMax: secondary?.max,
         secondaryEntity: secondary?.entity,
+        secondaryStateText: secondary?.state_text,
         secondarySegments: secondary?.segments
       };
 

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -18,6 +18,7 @@ export type SecondaryEntity = {
     show_state?: boolean;
     show_unit?: boolean;
     needle?: boolean;
+    state_text?: string;
     gauge_width?: number;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;
@@ -46,6 +47,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     show_unit?: boolean;
     show_icon?: boolean;
     needle?: boolean;
+    state_text?: string;
     adaptive_icon_color?: boolean;
     adaptive_state_color?: boolean;
     smooth_segments?: boolean;


### PR DESCRIPTION
Adds `state_text` config for both card and badge which overrides displayed entity text with set text content or template.