### PR TITLE
fix: incorrect theme color handling with smooth segments

### DIFF
--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -273,7 +273,7 @@ export class ModernCircularGaugeBadge extends LitElement {
         hasDoubleClick: hasAction(this._config.double_tap_action),
       })}
       .iconOnly=${content === undefined}
-      style=${styleMap({ "--gauge-color": computeSegments(numberState, segments, this._config.smooth_segments) })}
+      style=${styleMap({ "--gauge-color": computeSegments(numberState, segments, this._config.smooth_segments, this) })}
       .label=${label}
     >
       <div class=${classMap({ "container": true, "icon-only": content === undefined })} slot="icon">

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -211,7 +211,7 @@ export class ModernCircularGauge extends LitElement {
       </div>
       ` : nothing}
       <div class="container"
-        style=${styleMap({ "--gauge-color": gaugeForegroundColor && gaugeForegroundColor != "adaptive" ? gaugeForegroundColor : computeSegments(numberState, segments, this._config.smooth_segments) })}
+        style=${styleMap({ "--gauge-color": gaugeForegroundColor && gaugeForegroundColor != "adaptive" ? gaugeForegroundColor : computeSegments(numberState, segments, this._config.smooth_segments, this) })}
       >
         <svg viewBox="-50 -50 100 100" preserveAspectRatio="xMidYMid"
           overflow="visible"
@@ -408,7 +408,7 @@ export class ModernCircularGauge extends LitElement {
     return svg`
     <g 
       class="inner"
-      style=${styleMap({ "--gauge-color": gaugeForegroundColor && gaugeForegroundColor != "adaptive" ? gaugeForegroundColor : computeSegments(numberState, (this._templateResults?.secondarySegments as unknown) as SegmentsConfig[] ?? secondaryObj.segments, this._config?.smooth_segments) })}
+      style=${styleMap({ "--gauge-color": gaugeForegroundColor && gaugeForegroundColor != "adaptive" ? gaugeForegroundColor : computeSegments(numberState, (this._templateResults?.secondarySegments as unknown) as SegmentsConfig[] ?? secondaryObj.segments, this._config?.smooth_segments, this) })}
       >
       <mask id="gradient-current-inner-path">
         ${current ? renderPath("arc current", innerPath, current, styleMap({ "stroke": "white", "visibility": numberState <= min && min >= 0 ? "hidden" : "visible" })) : nothing}
@@ -507,9 +507,9 @@ export class ModernCircularGauge extends LitElement {
 
     if (secondary.adaptive_state_color) {
       if (secondary.show_gauge == "outter") {
-        secondaryColor = computeSegments(Number(state), this._config?.segments, this._config?.smooth_segments);
+        secondaryColor = computeSegments(Number(state), this._config?.segments, this._config?.smooth_segments, this);
       } else if (secondary.show_gauge == "inner") {
-        secondaryColor = computeSegments(Number(state), secondary.segments, this._config?.smooth_segments);
+        secondaryColor = computeSegments(Number(state), secondary.segments, this._config?.smooth_segments, this);
       }
     }
 

--- a/src/utils/gauge.ts
+++ b/src/utils/gauge.ts
@@ -174,7 +174,7 @@ export function renderSegments(segments: SegmentsConfig[], min: number, max: num
   return [];
 }
 
-export function computeSegments(numberState: number, segments: SegmentsConfig[] | undefined, smooth_segments: boolean | undefined): string | undefined {
+export function computeSegments(numberState: number, segments: SegmentsConfig[] | undefined, smooth_segments: boolean | undefined, element?: Element): string | undefined {
   if (segments) {
     let sortedSegments = [...segments].sort((a, b) => Number(a.from) - Number(b.from));
     
@@ -183,9 +183,19 @@ export function computeSegments(numberState: number, segments: SegmentsConfig[] 
       if (segment && (numberState >= Number(segment.from) || i === 0) &&
         (i + 1 == sortedSegments?.length || numberState < Number(sortedSegments![i + 1].from))) {
           if (smooth_segments) {
-            const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+            let color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+
+            if (color.includes("var(--") && element) {
+              color = getComputedStyle(element).getPropertyValue(color.replace(/(var\()|(\))/g, "").trim());
+            }
+
             const nextSegment = sortedSegments[i + 1] ? sortedSegments[i + 1] : segment;
-            const nextColor = typeof nextSegment.color === "object" ? rgbToHex(nextSegment.color) : nextSegment.color;
+            let nextColor = typeof nextSegment.color === "object" ? rgbToHex(nextSegment.color) : nextSegment.color;
+
+            if (nextColor.includes("var(--") && element) {
+              nextColor = getComputedStyle(element).getPropertyValue(nextColor.replace(/(var\()|(\))/g, "").trim());
+            }
+
             return interpolateRgb(color, nextColor)(valueToPercentage(numberState, Number(segment.from), Number(nextSegment.from)));
           } else {
             const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;


### PR DESCRIPTION
Fixes theme color variables handling with `smooth_segments: true`
Before:
![borken](https://github.com/user-attachments/assets/f25a0d24-f22f-41c8-8ff8-0a58725f2fa2)
After:
![fixed](https://github.com/user-attachments/assets/39100ca5-cade-415a-bc49-0f174ac65f90)

Color segments config used:
```yaml
segments:
  - from: 25
    color: var(--red-color)
  - from: 20
    color: var(--green-color)
```