### PR TITLE
feat: gauge start from zero config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | adaptive_icon_color | `boolean` | `false` | Makes icon color adaptive to current color segment
 | adaptive_state_color | `boolean` | `false` | Makes state color adaptive to current color segment
 | smooth_segments | `boolean` | `false` | Smooth color segments
+| start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | state_font_size | `number` | `24` | Initial state size in px
 | header_font_size | `number` | `14` | Gauge header font size in px
 | header_offset | `number` | `0` | Gauge header vertical offset in px
@@ -96,6 +97,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_state | `bool` | `true` | Show entity state
 | show_icon | `bool` | `false` | Show icon
 | needle | `bool` | `false` | 
+| start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | state_text | `string` | Entity state | Displayed state override. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | smooth_segments | `boolean` | `false` | Smooth color segments
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
@@ -119,6 +121,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | state_size | `small` or `big` | `small` | Secondary state size 
 | show_state | `boolean` | `true` | Show secondary state
 | show_unit | `boolean` | `true` | Show secondary unit
+| start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | gauge_background_style | `object` | Optional | Gauge background style, see [gauge element style object](#gauge-element-style-object)
 | gauge_foreground_style | `object` | Optional | Gauge foreground style, see [gauge element style object](#gauge-element-style-object)
 | needle | `boolean` | `false` |

--- a/src/badge/gauge-badge-config.ts
+++ b/src/badge/gauge-badge-config.ts
@@ -13,6 +13,7 @@ export interface ModernCircularGaugeBadgeConfig extends LovelaceBadgeConfig {
   show_icon?: boolean;
   needle?: boolean;
   state_text?: string;
+  start_from_zero?: boolean;
   smooth_segments?: boolean;
   segments?: SegmentsConfig[];
 }

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -7,7 +7,7 @@ import { getNumberFormatOptions, formatNumber } from "../utils/format_number";
 import { registerCustomBadge } from "../utils/custom-badges";
 import { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import { styleMap } from "lit/directives/style-map.js";
-import { svgArc, strokeDashArc, computeSegments, getAngle, renderPath, renderColorSegments } from "../utils/gauge";
+import { svgArc, strokeDashArc, computeSegments, getAngle, renderPath, renderColorSegments, currentDashArc } from "../utils/gauge";
 import { classMap } from "lit/directives/class-map.js";
 import { ActionHandlerEvent } from "../ha/data/lovelace";
 import { hasAction } from "../ha/panels/lovelace/common/has-action";
@@ -250,7 +250,7 @@ export class ModernCircularGaugeBadge extends LitElement {
     const numberState = Number(templatedState ?? stateObj.state);
 
     
-    const current = this._config.needle ? undefined : strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0, min, max, RADIUS);
+    const current = this._config.needle ? undefined : currentDashArc(numberState, min, max, RADIUS, this._config.start_from_zero);
     const state = templatedState ?? stateObj.state;
 
     const stateOverride = this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : this._config.state_text);

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -2,7 +2,7 @@ import { html, LitElement, TemplateResult, css, svg, nothing, PropertyValues } f
 import { customElement, property, state } from "lit/decorators.js";
 import { ActionHandlerEvent } from "../ha/data/lovelace";
 import { hasAction } from "../ha/panels/lovelace/common/has-action";
-import { svgArc, strokeDashArc, renderColorSegments, computeSegments, renderPath } from "../utils/gauge";
+import { svgArc, strokeDashArc, renderColorSegments, computeSegments, renderPath, currentDashArc } from "../utils/gauge";
 import { registerCustomCard } from "../utils/custom-cards";
 import type { ModernCircularGaugeConfig, SecondaryEntity, SegmentsConfig } from "./type";
 import { LovelaceLayoutOptions, LovelaceGridOptions } from "../ha/data/lovelace";
@@ -171,7 +171,7 @@ export class ModernCircularGauge extends LitElement {
     const min = Number(this._templateResults?.min?.result ?? this._config.min) || DEFAULT_MIN;
     const max = Number(this._templateResults?.max?.result ?? this._config.max) || DEFAULT_MAX;
 
-    const current = this._config.needle ? undefined : strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0, min, max, RADIUS);
+    const current = this._config.needle ? undefined : currentDashArc(numberState, min, max, RADIUS, this._config.start_from_zero);
     const needle = this._config.needle ? strokeDashArc(numberState, numberState, min, max, RADIUS) : undefined;
 
     const state = templatedState ?? stateObj.state;
@@ -397,7 +397,7 @@ export class ModernCircularGauge extends LitElement {
     const min = Number(this._templateResults?.secondaryMin?.result ?? secondaryObj.min) || DEFAULT_MIN; 
     const max = Number(this._templateResults?.secondaryMax?.result ?? secondaryObj.max) || DEFAULT_MAX;
 
-    const current = secondaryObj.needle ? undefined : strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0, min, max, INNER_RADIUS);
+    const current = secondaryObj.needle ? undefined : currentDashArc(numberState, min, max, INNER_RADIUS, secondaryObj.start_from_zero);
     const needle = secondaryObj.needle ? strokeDashArc(numberState, numberState, min, max, INNER_RADIUS) : undefined;
 
     const segments = (this._templateResults?.secondarySegments as unknown) as SegmentsConfig[] ?? secondaryObj.segments;

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -19,6 +19,7 @@ export type SecondaryEntity = {
     show_unit?: boolean;
     needle?: boolean;
     state_text?: string;
+    start_from_zero?: boolean;
     gauge_width?: number;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;
@@ -54,6 +55,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     state_font_size?: number;
     header_font_size?: number;
     header_offset?: number;
+    start_from_zero?: boolean;
     gauge_width?: number;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;

--- a/src/utils/gauge.ts
+++ b/src/utils/gauge.ts
@@ -99,6 +99,14 @@ export const valueToPercentage = (value: number, min: number, max: number) => {
   return (clamp(value, min, max) - min) / (max - min);
 }
 
+export const currentDashArc = (value: number, min: number, max: number, radius: number, startFromZero?: boolean): [string, string] => {
+  if (startFromZero) {
+    return strokeDashArc(value > 0 ? 0 : value, value > 0 ? value : 0, min, max, radius);
+  } else {
+    return strokeDashArc(min, value, min, max, radius);
+  }
+}
+
 export function renderPath(pathClass: DirectiveResult<typeof ClassMapDirective>, d: string, strokeDash: [string, string] | undefined = undefined, style: DirectiveResult<typeof StyleMapDirective> | undefined = undefined): TemplateResult {
   return svg`
     <path


### PR DESCRIPTION
Adds `start_from_zero` boolean config, which dictates gauge track to start from zero or from minimum specified value.
From now on by default gauge will start from min.

`start_from_zero: false`
![brave_muZGlZNJ4y](https://github.com/user-attachments/assets/80c90903-e5bf-4f58-b196-20d32fa5dce4)
`start_from_zero: true`
![brave_rJPIQeW8It](https://github.com/user-attachments/assets/2ec35da1-b992-47cc-9c2d-72f02ea09de0)