### PR TITLE
feat: tertiary info

### DIFF
--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -3,8 +3,8 @@ import { HomeAssistant } from "../ha/types";
 import { html, LitElement, nothing, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ModernCircularGaugeConfig } from "./type";
-import { mdiSegment, mdiInformationOutline } from "@mdi/js";
-import { hexToRgb } from "../utils/color";
+import { mdiSegment, mdiInformationOutline, mdiNumeric3BoxOutline } from "@mdi/js";
+import { getSecondarySchema, getTertiarySchema } from "./mcg-schema";
 import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS } from "../const";
 import memoizeOne from "memoize-one";
 import "../components/ha-form-mcg-list";
@@ -32,29 +32,29 @@ export class ModernCircularGaugeEditor extends LitElement {
   }
 
   private _schema = memoizeOne(
-    (showInnerGaugeOptions: boolean) =>
+    (showInnerGaugeOptions: boolean, showTertiaryGaugeOptions: boolean) =>
     [
+      {
+        name: "entity",
+        required: true,
+        selector: { entity: {
+          domain: NUMBER_ENTITY_DOMAINS,
+        }},
+      },
+      {
+        name: "name",
+        selector: { text: {} },
+      },
       {
         name: "",
         type: "grid",
         schema: [
-          {
-            name: "entity",
-            required: true,
-            selector: { entity: {
-              domain: NUMBER_ENTITY_DOMAINS,
-            }},
-          },
           {
             name: "icon",
             selector: { icon: {} },
             context: {
               icon_entity: "entity",
             },
-          },
-          {
-            name: "name",
-            selector: { text: {} },
           },
           {
             name: "unit",
@@ -74,133 +74,8 @@ export class ModernCircularGaugeEditor extends LitElement {
           },
         ],
       },
-      {
-        name: "secondary",
-        type: "expandable",
-        label: "Secondary info",
-        iconPath: mdiInformationOutline,
-        schema: [
-          {
-            name: "",
-            type: "grid",
-            schema: [
-              {
-                name: "entity",
-                selector: { entity: { 
-                  domain: NUMBER_ENTITY_DOMAINS,
-                }},
-              },
-              {
-                name: "unit",
-                selector: { text: {} },
-              },
-            ]
-          },
-          {
-            name: "state_size",
-            label: "State size",
-            selector: { select: {
-              options: [
-                { value: "small", label: "Small"},
-                { value: "big", label: "Big"},
-              ],
-              mode: "dropdown",
-            }},
-          },
-          {
-            name: "show_gauge",
-            label: "Gauge visibility",
-            selector: { select: {
-              options: [
-                { value: "none", label: "None" },
-                { value: "inner", label: "Inner gauge" },
-                { value: "outter", label: "Outter gauge" },
-              ],
-              mode: "dropdown",
-            }},
-          },
-          {
-            name: "",
-            type: "grid",
-            disabled: !showInnerGaugeOptions,
-            schema: [
-              {
-                name: "min",
-                default: DEFAULT_MIN,
-                label: "generic.minimum",
-                selector: { number: { step: 0.1 } },
-              },
-              {
-                name: "max",
-                default: DEFAULT_MAX,
-                label: "generic.maximum",
-                selector: { number: { step: 0.1 } },
-              },
-              {
-                name: "needle",
-                label: "gauge.needle_gauge",
-                selector: { boolean: {} },
-              },
-            ],
-          },
-          {
-            name: "",
-            type: "grid",
-            schema: [
-              {
-                name: "show_state",
-                label: "Show state",
-                default: true,
-                selector: { boolean: {} },
-              },
-              {
-                name: "show_unit",
-                label: "Show unit",
-                default: true,
-                selector: { boolean: {} },
-              },
-              {
-                name: "adaptive_state_color",
-                label: "Adaptive state color",
-                default: false,
-                selector: { boolean: {} },
-              },
-            ],
-          },
-          {
-            name: "segments",
-            type: "mcg-list",
-            title: "Color segments",
-            iconPath: mdiSegment,
-            disabled: !showInnerGaugeOptions,
-            schema: [
-              {
-                name: "",
-                type: "grid",
-                column_min_width: "100px",
-                schema: [
-                  {
-                    name: "from",
-                    label: "From",
-                    required: true,
-                    selector: { number: { step: 0.1 } },
-                  },
-                  {
-                    name: "color",
-                    label: "heading.entity_config.color",
-                    required: true,
-                    selector: { color_rgb: {} },
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            name: "tap_action",
-            selector: { ui_action: {} },
-          }
-        ],
-      },
+        getSecondarySchema(showInnerGaugeOptions),
+        getTertiarySchema(showTertiaryGaugeOptions),
       {
         name: "header_position",
         label: "Header position",
@@ -312,7 +187,7 @@ export class ModernCircularGaugeEditor extends LitElement {
       return nothing;
     }
 
-    const schema = this._schema(typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner");
+    const schema = this._schema(typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner", typeof this._config.tertiary != "string" && this._config.tertiary?.show_gauge == "inner");
 
     const DATA = {
       ...this._config,

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -1,0 +1,182 @@
+import { mdiNumeric2BoxOutline, mdiSegment, mdiNumeric3BoxOutline } from "@mdi/js";
+import { NUMBER_ENTITY_DOMAINS, DEFAULT_MIN, DEFAULT_MAX } from "../const";
+
+export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
+  return [
+    {
+      name: "show_gauge",
+      label: "Gauge visibility",
+      selector: { select: {
+        options: [
+          { value: "none", label: "None" },
+          { value: "inner", label: "Inner gauge" },
+          { value: "outter", label: "Outter gauge" },
+        ],
+        mode: "dropdown",
+      }},
+    },
+    {
+      name: "",
+      type: "grid",
+      disabled: !showGaugeOptions,
+      schema: [
+        {
+          name: "min",
+          default: DEFAULT_MIN,
+          label: "generic.minimum",
+          selector: { number: { step: 0.1 } },
+        },
+        {
+          name: "max",
+          default: DEFAULT_MAX,
+          label: "generic.maximum",
+          selector: { number: { step: 0.1 } },
+        },
+        {
+          name: "needle",
+          label: "gauge.needle_gauge",
+          selector: { boolean: {} },
+        },
+      ],
+    },
+    {
+      name: "segments",
+      type: "mcg-list",
+      title: "Color segments",
+      iconPath: mdiSegment,
+      disabled: !showGaugeOptions,
+      schema: [
+        {
+          name: "",
+          type: "grid",
+          column_min_width: "100px",
+          schema: [
+            {
+              name: "from",
+              label: "From",
+              required: true,
+              selector: { number: { step: 0.1 } },
+            },
+            {
+              name: "color",
+              label: "heading.entity_config.color",
+              required: true,
+              selector: { color_rgb: {} },
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+export function getSecondarySchema(showGaugeOptions: boolean) {
+  return {
+    name: "secondary",
+    type: "expandable",
+    label: "Secondary info",
+    iconPath: mdiNumeric2BoxOutline,
+    schema: [
+      {
+        name: "entity",
+        selector: { entity: { 
+          domain: NUMBER_ENTITY_DOMAINS,
+        }},
+      },
+      {
+        name: "",
+        type: "grid",
+        schema: [
+          {
+            name: "unit",
+            selector: { text: {} },
+          },
+          {
+            name: "state_size",
+            label: "State size",
+            selector: { select: {
+              options: [
+                { value: "small", label: "Small"},
+                { value: "big", label: "Big"},
+              ],
+              mode: "dropdown",
+            }},
+          },
+          {
+            name: "show_state",
+            label: "Show state",
+            default: true,
+            selector: { boolean: {} },
+          },
+          {
+            name: "show_unit",
+            label: "Show unit",
+            default: true,
+            selector: { boolean: {} },
+          },
+          {
+            name: "adaptive_state_color",
+            label: "Adaptive state color",
+            default: false,
+            selector: { boolean: {} },
+          },
+        ],
+      },
+      ...getSecondaryGaugeSchema(showGaugeOptions),
+      {
+        name: "tap_action",
+        selector: { ui_action: {} },
+      }
+    ],
+  }
+}
+
+export function getTertiarySchema(showGaugeOptions: boolean) {
+  return {
+    name: "tertiary",
+    type: "expandable",
+    label: "Tertiary info",
+    iconPath: mdiNumeric3BoxOutline,
+    schema: [
+      {
+        name: "entity",
+        selector: { entity: { 
+          domain: NUMBER_ENTITY_DOMAINS,
+        }},
+      },
+      {
+        name: "unit",
+        selector: { text: {} },
+      },
+      {
+        name: "",
+        type: "grid",
+        schema: [
+          {
+            name: "show_state",
+            label: "Show state",
+            default: true,
+            selector: { boolean: {} },
+          },
+          {
+            name: "show_unit",
+            label: "Show unit",
+            default: true,
+            selector: { boolean: {} },
+          },
+          {
+            name: "adaptive_state_color",
+            label: "Adaptive state color",
+            default: false,
+            selector: { boolean: {} },
+          },
+        ],
+      },
+      ...getSecondaryGaugeSchema(showGaugeOptions),
+      {
+        name: "tap_action",
+        selector: { ui_action: {} },
+      }
+    ],
+  }
+}

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -586,7 +586,15 @@ export class ModernCircularGauge extends LitElement {
     let adaptiveColor;
 
     if (tertiary.adaptive_state_color) {
-      adaptiveColor = computeSegments(Number(state), tertiary.segments, this._config?.smooth_segments, this);
+      if (tertiary.show_gauge == "outter") {
+        adaptiveColor = computeSegments(Number(state), (this._templateResults?.segments?.result as unknown) as SegmentsConfig[] ?? this._config?.segments, this._config?.smooth_segments, this);
+      } else if (tertiary.show_gauge == "inner") {
+        adaptiveColor = computeSegments(Number(state), tertiary.segments, this._config?.smooth_segments, this);
+      }
+
+      if (tertiary.gauge_foreground_style?.color && tertiary.gauge_foreground_style?.color != "adaptive") {
+        adaptiveColor = tertiary.gauge_foreground_style?.color;
+      }
     }
 
     return svg`
@@ -658,9 +666,13 @@ export class ModernCircularGauge extends LitElement {
 
     if (secondary.adaptive_state_color) {
       if (secondary.show_gauge == "outter") {
-        secondaryColor = computeSegments(Number(state), this._config?.segments, this._config?.smooth_segments, this);
+        secondaryColor = computeSegments(Number(state), (this._templateResults?.segments?.result as unknown) as SegmentsConfig[] ?? this._config?.segments, this._config?.smooth_segments, this);
       } else if (secondary.show_gauge == "inner") {
         secondaryColor = computeSegments(Number(state), secondary.segments, this._config?.smooth_segments, this);
+      }
+
+      if (secondary.gauge_foreground_style?.color && secondary.gauge_foreground_style?.color != "adaptive") {
+        secondaryColor = secondary.gauge_foreground_style?.color;
       }
     }
 

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -529,7 +529,9 @@ export class ModernCircularGauge extends LitElement {
       `;
     }
 
-    if (!(tertiary.show_state ?? true)) {
+    const bigState = typeof this._config?.secondary == "object" ? this._config?.secondary?.state_size == "big" : false;
+
+    if (!(tertiary.show_state ?? true) || bigState) {
       return svg``;
     }
 

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -487,7 +487,7 @@ export class ModernCircularGauge extends LitElement {
       const current = strokeDashArc(numberState, numberState, min, max, RADIUS);
   
       return svg`
-      ${renderPath("dot border tertiary", path, current, styleMap({ "opacity": tertiaryObj.gauge_foreground_style?.opacity ?? 1, "stroke": tertiaryObj.gauge_foreground_style?.color, "stroke-width": tertiaryObj.gauge_foreground_style?.width }))}
+      ${!tertiaryObj.gauge_foreground_style?.color ? renderPath("dot border tertiary", path, current, styleMap({ "opacity": tertiaryObj.gauge_foreground_style?.opacity ?? 1, "stroke": tertiaryObj.gauge_foreground_style?.color, "stroke-width": tertiaryObj.gauge_foreground_style?.width })) : nothing}
       ${renderPath("dot", path, current, styleMap({ "opacity": tertiaryObj.gauge_foreground_style?.opacity ?? 1, "stroke": tertiaryObj.gauge_foreground_style?.color, "stroke-width": tertiaryObj.gauge_foreground_style?.width }))}
       `;
     }
@@ -539,7 +539,7 @@ export class ModernCircularGauge extends LitElement {
     const current = strokeDashArc(numberState, numberState, min, max, RADIUS);
 
     return svg`
-    ${renderPath("dot border secondary", path, current, styleMap({ "opacity": secondaryObj.gauge_foreground_style?.opacity ?? 1, "stroke": secondaryObj.gauge_foreground_style?.color, "stroke-width": secondaryObj.gauge_foreground_style?.width }))}
+    ${!secondaryObj.gauge_foreground_style?.color ? renderPath("dot border secondary", path, current, styleMap({ "opacity": secondaryObj.gauge_foreground_style?.opacity ?? 1, "stroke-width": secondaryObj.gauge_foreground_style?.width })) : nothing}
     ${renderPath("dot", path, current, styleMap({ "opacity": secondaryObj.gauge_foreground_style?.opacity ?? 1, "stroke": secondaryObj.gauge_foreground_style?.color, "stroke-width": secondaryObj.gauge_foreground_style?.width }))}
     `;
   }

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -405,12 +405,12 @@ export class ModernCircularGauge extends LitElement {
       `;
     }
 
-    const current = needle ? undefined : strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0, min, max, radius);
+    const current = needle ? undefined : currentDashArc(numberState, min, max, radius, this._config?.start_from_zero);
     const needleArc = needle ? strokeDashArc(numberState, numberState, min, max, radius) : undefined;
 
     return svg`
     <g class="${gaugeName}"
-      style=${styleMap({ "--gauge-color": foregroundStyle?.color && foregroundStyle.color != "adaptive" ? foregroundStyle.color : computeSegments(numberState, segments, this._config?.smooth_segments) })}
+      style=${styleMap({ "--gauge-color": foregroundStyle?.color && foregroundStyle.color != "adaptive" ? foregroundStyle.color : computeSegments(numberState, segments, this._config?.smooth_segments, this) })}
     >
       <mask id="gradient-current-${gaugeName}-path">
         ${current ? renderPath("arc current", d, current, styleMap({ "stroke": "white", "visibility": numberState <= min && min >= 0 ? "hidden" : "visible" })) : nothing}

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -276,7 +276,7 @@ export class ModernCircularGauge extends LitElement {
               ` : nothing}
           </g>
         </svg>
-        <svg class="state" overflow="visible" viewBox="-50 ${iconCenter ? -55 : -50} 100 100">
+        <svg class="state" overflow="visible" viewBox="-50 -50 100 100">
           ${this._config.show_state ? svg`
           <text
             x="0" y="0" 
@@ -550,12 +550,14 @@ export class ModernCircularGauge extends LitElement {
       return svg``;
     }
 
+    const iconCenter = !(this._config?.show_state ?? false) && (this._config?.show_icon ?? true);
+
     if (typeof tertiary === "string") {
       return svg`
       <text
         x="0" y="0"
         class="tertiary-state"
-        dy=-19
+        dy=${iconCenter ? -19 : -16}
       >
         ${this._templateResults?.tertiary?.result ?? this._config?.tertiary}
       </text>
@@ -596,7 +598,7 @@ export class ModernCircularGauge extends LitElement {
       })}
       class="tertiary-state ${classMap({ "adaptive": !!tertiary.adaptive_state_color })}"
       style=${styleMap({ "fill": adaptiveColor ?? undefined })}
-      dy=-16
+      dy=${iconCenter ? -19 : -16}
     >
       ${entityState}
       ${(tertiary.show_unit ?? true) && !tertiary.state_text ? svg`
@@ -617,13 +619,15 @@ export class ModernCircularGauge extends LitElement {
       return svg``;
     }
 
+    const iconCenter = !(this._config?.show_state ?? false) && (this._config?.show_icon ?? true);
+
     if (typeof secondary === "string") {
       this._hasSecondary = true;
       return svg`
       <text
         x="0" y="0"
         class="secondary"
-        dy=19
+        dy=${iconCenter ? 25 : 20}
       >
         ${this._templateResults?.secondary?.result ?? this._config?.secondary}
       </text>`;
@@ -671,7 +675,7 @@ export class ModernCircularGauge extends LitElement {
       style=${styleMap({ "font-size": secondary.state_size == "big" ? this._calcStateSize(entityState) : undefined,
         "fill": secondaryColor ?? undefined
        })}
-      dy=${secondary.state_size == "big" ? 14 : 20}
+      dy=${secondary.state_size == "big" ? 14 : iconCenter ? 25 : 20}
     >
       ${entityState}
       ${(secondary.show_unit ?? true) && !secondary.state_text ? svg`

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -181,7 +181,6 @@ export class ModernCircularGauge extends LitElement {
     const max = Number(this._templateResults?.max?.result ?? this._config.max) || DEFAULT_MAX;
 
     const current = this._config.needle ? undefined : strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0, min, max, RADIUS);
-    const currentTertiary = this._config.needle ? undefined : strokeDashArc(numberState > 0 ? 0 : numberState, numberState > 0 ? numberState : 0, min, max, TERTIARY_RADIUS);
     const needle = this._config.needle ? strokeDashArc(numberState, numberState, min, max, RADIUS) : undefined;
 
     const state = templatedState ?? stateObj.state;

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -517,7 +517,7 @@ export class ModernCircularGauge extends LitElement {
       return svg`
       <text
         x="0" y="0"
-        class="tertiary"
+        class="tertiary-state"
         dy=-19
       >
         ${this._templateResults?.tertiary?.result ?? this._config?.tertiary}
@@ -549,7 +549,7 @@ export class ModernCircularGauge extends LitElement {
         hasHold: hasAction(tertiary.hold_action),
         hasDoubleClick: hasAction(tertiary.double_tap_action),
       })}
-      class="tertiary ${classMap({ "adaptive": !!tertiary.adaptive_state_color })}"
+      class="tertiary-state ${classMap({ "adaptive": !!tertiary.adaptive_state_color })}"
       dy=-16
     >
       ${entityState}
@@ -928,9 +928,14 @@ export class ModernCircularGauge extends LitElement {
       margin-bottom: 0px;
     }
 
-    .secondary, .tertiary {
+    .secondary, .tertiary-state {
       font-size: 10px;
       fill: var(--secondary-text-color);
+      --gauge-color: var(--gauge-secondary-color);
+    }
+
+    .tertiary-state {
+      --gauge-color: var(--gauge-tertiary-color);
     }
 
     .state-label {
@@ -1018,7 +1023,7 @@ export class ModernCircularGauge extends LitElement {
       color: var(--gauge-color);
     }
 
-    .value.adaptive, .secondary.adaptive {
+    .value.adaptive, .secondary.adaptive, .tertiary-state.adaptive {
       fill: var(--gauge-color);
     }
 

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -542,6 +542,12 @@ export class ModernCircularGauge extends LitElement {
     const stateOverride = this._templateResults?.tertiaryStateText?.result ?? (isTemplate(String(tertiary.state_text)) ? "" : tertiary.state_text);
     const entityState = stateOverride ?? formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
+    let adaptiveColor;
+
+    if (tertiary.adaptive_state_color) {
+      adaptiveColor = computeSegments(Number(state), tertiary.segments, this._config?.smooth_segments, this);
+    }
+
     return svg`
     <text
       @action=${this._handleTertiaryAction}
@@ -550,6 +556,7 @@ export class ModernCircularGauge extends LitElement {
         hasDoubleClick: hasAction(tertiary.double_tap_action),
       })}
       class="tertiary-state ${classMap({ "adaptive": !!tertiary.adaptive_state_color })}"
+      style=${styleMap({ "fill": adaptiveColor ?? undefined })}
       dy=-16
     >
       ${entityState}

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -609,7 +609,7 @@ export class ModernCircularGauge extends LitElement {
       dy=${iconCenter ? -19 : -16}
     >
       ${entityState}
-      ${(tertiary.show_unit ?? true) && !tertiary.state_text ? svg`
+      ${(tertiary.show_unit ?? true) ? svg`
       <tspan
         dx=0
         dy=0

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -397,12 +397,16 @@ export class ModernCircularGauge extends LitElement {
   private _renderGaugeRing(gaugeName: string, state: string, min: number, max: number, d: string, radius: number, needle?: boolean , segments?: SegmentsConfig[], foregroundStyle?: GaugeElementConfig, backgroundStyle?: GaugeElementConfig): TemplateResult {
     const numberState = Number(state);
 
-    if (state === "unavailable" || isNaN(numberState)) {
+    if (state === "unavailable") {
       return svg`
       <g class="${gaugeName}">
         ${renderPath("arc clear", d)}
       </g>
       `;
+    }
+
+    if (isNaN(numberState)) {
+      return svg``;
     }
 
     const current = needle ? undefined : currentDashArc(numberState, min, max, radius, this._config?.start_from_zero);
@@ -680,7 +684,8 @@ export class ModernCircularGauge extends LitElement {
       max: this._config?.max,
       segments: this._config?.segments,
       stateText: this._config?.state_text,
-      secondary: this._config?.secondary
+      secondary: this._config?.secondary,
+      tertiary: this._config?.tertiary
     };
     
     Object.entries(templates).forEach(([key, value]) => {
@@ -706,6 +711,26 @@ export class ModernCircularGauge extends LitElement {
         if (typeof value == "string") {
           this._tryConnectKey(key, value);
         } else if (key == "secondarySegments") {
+          const segmentsStringified = JSON.stringify(value);
+          this._tryConnectKey(key, segmentsStringified);
+        }
+      });
+    }
+
+    if (typeof this._config?.tertiary != "string") {
+      const tertiary = this._config?.tertiary;
+      const tertiaryTemplates = {
+        tertiaryMin: tertiary?.min,
+        tertiaryMax: tertiary?.max,
+        tertiaryEntity: tertiary?.entity,
+        tertiaryStateText: tertiary?.state_text,
+        tertiarySegments: tertiary?.segments
+      };
+
+      Object.entries(tertiaryTemplates).forEach(([key, value]) => {
+        if (typeof value == "string") {
+          this._tryConnectKey(key, value);
+        } else if (key == "tertiarySegments") {
           const segmentsStringified = JSON.stringify(value);
           this._tryConnectKey(key, segmentsStringified);
         }
@@ -768,7 +793,8 @@ export class ModernCircularGauge extends LitElement {
       max: this._config?.max,
       segments: this._config?.segments,
       stateText: this._config?.state_text,
-      secondary: this._config?.secondary
+      secondary: this._config?.secondary,
+      tertiary: this._config?.tertiary
     };
     
     Object.entries(templates).forEach(([key, _]) => {
@@ -786,6 +812,21 @@ export class ModernCircularGauge extends LitElement {
       };
 
       Object.entries(secondaryTemplates).forEach(([key, _]) => {
+        this._tryDisconnectKey(key);
+      });
+    }
+
+    if (typeof this._config?.tertiary != "string") {
+      const tertiary = this._config?.tertiary;
+      const tertiaryTemplates = {
+        tertiaryMin: tertiary?.min,
+        tertiaryMax: tertiary?.max,
+        tertiaryEntity: tertiary?.entity,
+        tertiaryStateText: tertiary?.state_text,
+        tertiarySegments: tertiary?.segments
+      };
+
+      Object.entries(tertiaryTemplates).forEach(([key, _]) => {
         this._tryDisconnectKey(key);
       });
     }

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -6,26 +6,34 @@ export interface SegmentsConfig {
     label?: string;
 }
 
-export type SecondaryEntity = {
+export interface BaseEntityConfig {
     entity?: string;
     unit?: string;
     label?: string;
-    template?: string;
-    show_gauge?: "none" | "inner" | "outter";
     min?: number | string;
     max?: number | string;
-    state_size?: "small" | "big";
+    needle?: boolean;
     show_state?: boolean;
     show_unit?: boolean;
-    needle?: boolean;
     state_text?: string;
-    gauge_width?: number;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;
     adaptive_state_color?: boolean;
     segments?: SegmentsConfig[];
+}
+
+export interface SecondaryEntity extends BaseEntityConfig {
+    template?: string;
+    show_gauge?: "none" | "inner" | "outter";
+    state_size?: "small" | "big";
+    gauge_width?: number;
     [key: string]: any;
 };
+
+export interface TertiaryEntity extends BaseEntityConfig {
+    show_gauge?: boolean;
+    [key: string]: any;
+}
 
 export interface GaugeElementConfig {
     width?: number;
@@ -61,5 +69,6 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     state_scaling_multiplier?: number;
     segments?: SegmentsConfig[];
     secondary?: SecondaryEntity | string;
+    tertiary?: TertiaryEntity | string;
     secondary_entity?: SecondaryEntity; // Unused
 }

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -17,7 +17,6 @@ export interface BaseEntityConfig {
     show_unit?: boolean;
     state_text?: string;
     start_from_zero?: boolean;
-    gauge_width?: number;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;
     adaptive_state_color?: boolean;

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -32,7 +32,7 @@ export interface SecondaryEntity extends BaseEntityConfig {
 };
 
 export interface TertiaryEntity extends BaseEntityConfig {
-    show_gauge?: boolean;
+    show_gauge?: "none" | "inner" | "outter";
     [key: string]: any;
 }
 


### PR DESCRIPTION
Adds tertiary info above main state with ability to display third gauge inside the secondary gauge.
Tertiary info, unlike secondary info, has only one state size.
Apart from state size config, It has the same config as a secondary.
![brave_MVWdCzsav7](https://github.com/user-attachments/assets/f0fb6317-0bcc-4158-ae0b-4aa45b68de41)![brave_PcBTdFa1wp](https://github.com/user-attachments/assets/9328ab4a-a84b-4cc1-aaec-5f5744ca5548)
