### PR TITLE
feat: better badge customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 #### Gauge element style object
 | Name | Type | Default | Description |
 |------|:----:|:-------:|:------------|
-| width | `number` | `6 or 4` | Gauge element width
+| width | `number` | `6 or 4`, `14` for badge | Gauge element width
 | color | `string` or `adaptive` | Optional | Gauge element color
 | opacity | `number` | Optional | Gauge element opacity
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_icon | `bool` | `false` | Show icon
 | needle | `bool` | `false` | 
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
+| gauge_background_style | `object` | Optional | Gauge background style, see [gauge element style object](#gauge-element-style-object)
+| gauge_foreground_style | `object` | Optional | Gauge foreground style, see [gauge element style object](#gauge-element-style-object)
 | state_text | `string` | Entity state | Displayed state override. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)
 | smooth_segments | `boolean` | `false` | Smooth color segments
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)

--- a/src/badge/gauge-badge-config.ts
+++ b/src/badge/gauge-badge-config.ts
@@ -1,5 +1,5 @@
 import { LovelaceBadgeConfig } from "../ha/data/lovelace";
-import { SegmentsConfig } from "../card/type";
+import { GaugeElementConfig, SegmentsConfig } from "../card/type";
 
 export interface ModernCircularGaugeBadgeConfig extends LovelaceBadgeConfig {
   entity: string;
@@ -14,6 +14,8 @@ export interface ModernCircularGaugeBadgeConfig extends LovelaceBadgeConfig {
   needle?: boolean;
   state_text?: string;
   start_from_zero?: boolean;
+  gauge_foreground_style?: GaugeElementConfig;
+  gauge_background_style?: GaugeElementConfig;
   smooth_segments?: boolean;
   segments?: SegmentsConfig[];
 }


### PR DESCRIPTION
This adds enhanced badge background and foreground customization just like in #70. This includes:

- color: hex value or adaptive which results in a color segments displayed on gauge track
- opacity: opacity of an foreground or background
- width: gauge track width

![brave_RMTjLr88lb](https://github.com/user-attachments/assets/1d5519d3-4334-4bc4-8deb-21101c1b6a2d)
