### PR TITLE
fix: show unit with overriden state 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_name | `bool` | `false` | Show badge name
 | show_state | `bool` | `true` | Show entity state
 | show_icon | `bool` | `false` | Show icon
+| show_unit | `bool` | `true` | Show unit
 | needle | `bool` | `false` | 
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | state_text | `string` | Entity state | Displayed state override. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)

--- a/src/badge/gauge-badge-config.ts
+++ b/src/badge/gauge-badge-config.ts
@@ -11,6 +11,7 @@ export interface ModernCircularGaugeBadgeConfig extends LovelaceBadgeConfig {
   show_name?: boolean;
   show_state?: boolean;
   show_icon?: boolean;
+  show_unit?: boolean;
   needle?: boolean;
   state_text?: string;
   start_from_zero?: boolean;

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -63,6 +63,12 @@ const FORM = [
         selector: { boolean: {} },
       },
       {
+        name: "show_unit",
+        label: "Show unit",
+        default: true,
+        selector: { boolean: {} },
+      },
+      {
         name: "show_icon",
         label: "Show icon",
         default: false,

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -254,7 +254,7 @@ export class ModernCircularGaugeBadge extends LitElement {
     const state = templatedState ?? stateObj.state;
 
     const stateOverride = this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : this._config.state_text);
-    const unit = stateOverride ? "" : (this._config.unit ?? stateObj?.attributes.unit_of_measurement) || "";
+    const unit = this._config.show_unit ?? true ? (this._config.unit ?? stateObj?.attributes.unit_of_measurement) || "" : "";
 
     const entityState = stateOverride ?? formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
@@ -314,7 +314,9 @@ export class ModernCircularGaugeBadge extends LitElement {
           <svg class="state" viewBox="-50 -50 100 100">
             <text x="0" y="0" class="value" style=${styleMap({ "font-size": this._calcStateSize(entityState) })}>
               ${entityState}
+              ${this._config.show_unit ?? true ? svg`
               <tspan class="unit" dx="-4" dy="-6">${unit}</tspan>
+              ` : nothing}
             </text>
           </svg>
           ` : nothing}

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -268,7 +268,7 @@ export class ModernCircularGauge extends LitElement {
           >
             ${this._getSegmentLabel(numberState, segments) ? this._getSegmentLabel(numberState, segments) : svg`
               ${entityState}
-              ${(this._config.show_unit ?? true) && !this._config.state_text ? svg`<tspan class="unit" dx="-4" dy="-6">${unit}</tspan>` : nothing}
+              ${(this._config.show_unit ?? true) ? svg`<tspan class="unit" dx="-4" dy="-6">${unit}</tspan>` : nothing}
             `}
           </text>
           ${typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big"
@@ -527,7 +527,7 @@ export class ModernCircularGauge extends LitElement {
       dy=${secondary.state_size == "big" ? 14 : 20}
     >
       ${entityState}
-      ${(secondary.show_unit ?? true) && !secondary.state_text ? svg`
+      ${(secondary.show_unit ?? true) ? svg`
       <tspan
         class=${classMap({"unit": secondary.state_size == "big"})}
         dx=${secondary.state_size == "big" ? -4 : 0}


### PR DESCRIPTION
Unit was automatically hidden when state was overriden with `state_text`. This changes the behavior and now it's up to a user to hide the unit with `show_unit` config which was also added to badge.