### PR TITLE
feat: adjustable font size for secondary and tertiary

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_state | `boolean` | `true` | Show secondary state
 | show_unit | `boolean` | `true` | Show secondary unit
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
+| state_font_size | `number` | `10` or `24` | State size in px
 | gauge_background_style | `object` | Optional | Gauge background style, see [gauge element style object](#gauge-element-style-object)
 | gauge_foreground_style | `object` | Optional | Gauge foreground style, see [gauge element style object](#gauge-element-style-object)
 | needle | `boolean` | `false` |
@@ -143,6 +144,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_state | `boolean` | `true` | Show secondary state
 | show_unit | `boolean` | `true` | Show secondary unit
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
+| state_font_size | `number` | `10` | State size in px
 | gauge_background_style | `object` | Optional | Gauge background style, see [gauge element style object](#gauge-element-style-object)
 | gauge_foreground_style | `object` | Optional | Gauge foreground style, see [gauge element style object](#gauge-element-style-object)
 | needle | `boolean` | `false` |

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -377,8 +377,8 @@ export class ModernCircularGauge extends LitElement {
       `;
   }
 
-  private _calcStateSize(state: string): string {
-    let initialSize = this._config?.state_font_size ?? 24;
+  private _calcStateSize(state: string, initialStateSize?: number): string {
+    let initialSize = initialStateSize ?? this._config?.state_font_size ?? 24;
     if (typeof this._config?.secondary != "string") {
       initialSize -= this._config?.secondary?.show_gauge == "inner" ? 2 : 0;
       initialSize -= this._config?.secondary?.state_size == "big" ? 3 : 0;
@@ -684,7 +684,7 @@ export class ModernCircularGauge extends LitElement {
         hasDoubleClick: hasAction(secondary.double_tap_action),
       })}
       class="secondary ${classMap({ "dual-state": secondary.state_size == "big", "adaptive": !!secondary.adaptive_state_color })}"
-      style=${styleMap({ "font-size": secondary.state_size == "big" ? this._calcStateSize(entityState) : secondary.state_font_size ? `${secondary.state_font_size}px` : undefined,
+      style=${styleMap({ "font-size": secondary.state_size == "big" ? this._calcStateSize(entityState, secondary.state_font_size) : secondary.state_font_size ? `${secondary.state_font_size}px` : undefined,
         "fill": secondaryColor ?? undefined
        })}
       dy=${secondary.state_size == "big" ? 14 : iconCenter ? 25 : 20}

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -605,7 +605,7 @@ export class ModernCircularGauge extends LitElement {
         hasDoubleClick: hasAction(tertiary.double_tap_action),
       })}
       class="tertiary-state ${classMap({ "adaptive": !!tertiary.adaptive_state_color })}"
-      style=${styleMap({ "fill": adaptiveColor ?? undefined })}
+      style=${styleMap({ "fill": adaptiveColor ?? undefined, "font-size": tertiary.state_font_size ? `${tertiary.state_font_size}px` : undefined })}
       dy=${iconCenter ? -19 : -16}
     >
       ${entityState}
@@ -684,7 +684,7 @@ export class ModernCircularGauge extends LitElement {
         hasDoubleClick: hasAction(secondary.double_tap_action),
       })}
       class="secondary ${classMap({ "dual-state": secondary.state_size == "big", "adaptive": !!secondary.adaptive_state_color })}"
-      style=${styleMap({ "font-size": secondary.state_size == "big" ? this._calcStateSize(entityState) : undefined,
+      style=${styleMap({ "font-size": secondary.state_size == "big" ? this._calcStateSize(entityState) : secondary.state_font_size ? `${secondary.state_font_size}px` : undefined,
         "fill": secondaryColor ?? undefined
        })}
       dy=${secondary.state_size == "big" ? 14 : iconCenter ? 25 : 20}

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -16,6 +16,7 @@ export interface BaseEntityConfig {
     show_state?: boolean;
     show_unit?: boolean;
     state_text?: string;
+    state_font_size?: number;
     start_from_zero?: boolean;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;


### PR DESCRIPTION
Adds `state_font_size` config for adjustable font size for card secondary and tertiary info.