### PR TITLE
fix: increased needle border

### DIFF
--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -425,7 +425,7 @@ export class ModernCircularGaugeBadge extends LitElement {
     }
 
     .segments {
-      opacity: 0.35;
+      opacity: 0.45;
     }
 
     ha-badge {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -230,6 +230,12 @@ export class ModernCircularGauge extends LitElement {
         >
           <g transform="rotate(${ROTATE_ANGLE})">
             <defs>
+              ${needle ? svg`
+              <mask id="needle-border-mask">
+                <rect x="-60" y="-60" width="120" height="120" fill="white"/>
+                ${renderPath("needle-border", path, needle, styleMap({ "stroke": "black" }))}
+              </mask>`
+               : nothing}
               <mask id="gradient-path">
                 ${renderPath("arc", path, undefined, styleMap({ "stroke": "white", "stroke-width": this._config.gauge_background_style?.width ? `${this._config.gauge_background_style?.width}px` : undefined }))}
               </mask>
@@ -245,7 +251,7 @@ export class ModernCircularGauge extends LitElement {
                   : 'var(--inner-gauge-stroke-width)' : 'var(--inner-gauge-stroke-width)' }))}
               </mask>
             </defs>
-            <g class="background" style=${styleMap({ "opacity": this._config.gauge_background_style?.opacity,
+            <g class="background" mask=${ifDefined(needle ? "url(#needle-border-mask)" : undefined)} style=${styleMap({ "opacity": this._config.gauge_background_style?.opacity,
               "--gauge-stroke-width": this._config.gauge_background_style?.width ? `${this._config.gauge_background_style?.width}px` : undefined })}>
               ${renderPath("arc clear", path, undefined, styleMap({ "stroke": gaugeBackgroundColor && gaugeBackgroundColor != "adaptive" ? gaugeBackgroundColor : undefined }))}
               ${this._config.segments && (needle || this._config.gauge_background_style?.color == "adaptive") ? svg`
@@ -271,7 +277,6 @@ export class ModernCircularGauge extends LitElement {
               : nothing
             }
             ${needle ? svg`
-              ${renderPath("needle-border", path, needle)}
               ${renderPath("needle", path, needle)}
               ` : nothing}
           </g>
@@ -416,10 +421,16 @@ export class ModernCircularGauge extends LitElement {
     <g class="${gaugeName}"
       style=${styleMap({ "--gauge-color": foregroundStyle?.color && foregroundStyle.color != "adaptive" ? foregroundStyle.color : computeSegments(numberState, segments, this._config?.smooth_segments, this) })}
     >
+      ${needleArc ? svg`
+      <mask id="needle-border-${gaugeName}-mask">
+        <rect x="-60" y="-60" width="120" height="120" fill="white"/>
+        ${renderPath("needle-border", path, needleArc, styleMap({ "stroke": "black" }))}
+      </mask>`
+        : nothing}
       <mask id="gradient-current-${gaugeName}-path">
         ${current ? renderPath("arc current", d, current, styleMap({ "stroke": "white", "visibility": numberState <= min && min >= 0 ? "hidden" : "visible" })) : nothing}
       </mask>
-      <g class="background" style=${styleMap({ "opacity": backgroundStyle?.opacity,
+      <g class="background" mask=${ifDefined(needleArc ? `url(#needle-border-${gaugeName}-mask)` : undefined)} style=${styleMap({ "opacity": backgroundStyle?.opacity,
         "--gauge-stroke-width": backgroundStyle?.width ? `${backgroundStyle?.width}px` : undefined })}
       >
         ${renderPath("arc clear", d, undefined, styleMap({ "stroke": backgroundStyle?.color && backgroundStyle?.color != "adaptive" ? backgroundStyle?.color : undefined }))}
@@ -436,7 +447,6 @@ export class ModernCircularGauge extends LitElement {
         </g>
       ` : renderPath("arc current", d, current, styleMap({ "visibility": numberState <= min && min >= 0 ? "hidden" : "visible", "opacity": foregroundStyle?.opacity })) : nothing}
       ${needleArc ? svg`
-        ${renderPath("needle-border", d, needleArc)}
         ${renderPath("needle", d, needleArc)}
         ` : nothing}
     </g>
@@ -1193,7 +1203,7 @@ export class ModernCircularGauge extends LitElement {
     .needle-border {
       fill: none;
       stroke-linecap: round;
-      stroke-width: calc(var(--gauge-stroke-width) + 2px);
+      stroke-width: calc(var(--gauge-stroke-width) + 4px);
       stroke: var(--card-background-color);
       transition: all 1s ease 0s, stroke 0.3s ease-out;
     }

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -2,9 +2,9 @@ import { html, LitElement, TemplateResult, css, svg, nothing, PropertyValues } f
 import { customElement, property, state } from "lit/decorators.js";
 import { ActionHandlerEvent } from "../ha/data/lovelace";
 import { hasAction } from "../ha/panels/lovelace/common/has-action";
-import { svgArc, strokeDashArc, renderColorSegments, computeSegments, renderPath, currentDashArc } from "../utils/gauge";
+import { svgArc, computeSegments, renderPath } from "../utils/gauge";
 import { registerCustomCard } from "../utils/custom-cards";
-import type { BaseEntityConfig, GaugeElementConfig, ModernCircularGaugeConfig, SecondaryEntity, SegmentsConfig, TertiaryEntity } from "./type";
+import type { ModernCircularGaugeConfig, SecondaryEntity, SegmentsConfig, TertiaryEntity } from "./type";
 import { LovelaceLayoutOptions, LovelaceGridOptions } from "../ha/data/lovelace";
 import { handleAction } from "../ha/handle-action";
 import { HomeAssistant } from "../ha/types";
@@ -18,6 +18,7 @@ import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS, MAX_ANGLE } from "../c
 import { RenderTemplateResult, subscribeRenderTemplate } from "../ha/data/ws-templates";
 import { isTemplate } from "../utils/template";
 import { mdiHelp } from "@mdi/js";
+import "../components/modern-circular-gauge-element"
 
 const ROTATE_ANGLE = 360 - MAX_ANGLE / 2 - 90;
 const RADIUS = 47;
@@ -180,18 +181,12 @@ export class ModernCircularGauge extends LitElement {
     const min = Number(this._templateResults?.min?.result ?? this._config.min) || DEFAULT_MIN;
     const max = Number(this._templateResults?.max?.result ?? this._config.max) || DEFAULT_MAX;
 
-    const current = this._config.needle ? undefined : currentDashArc(numberState, min, max, RADIUS, this._config.start_from_zero);
-    const needle = this._config.needle ? strokeDashArc(numberState, numberState, min, max, RADIUS) : undefined;
-
     const state = templatedState ?? stateObj.state;
     const stateOverride = this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : this._config.state_text);
     const entityState = stateOverride ?? formatNumber(state, this.hass.locale, getNumberFormatOptions({ state, attributes } as HassEntity, this.hass.entities[stateObj?.entity_id])) ?? templatedState;
 
     const iconCenter = !(this._config.show_state ?? false) && (this._config.show_icon ?? true);
     const segments = (this._templateResults?.segments?.result as unknown) as SegmentsConfig[] ?? this._config.segments;
-
-    const gaugeBackgroundColor = this._config.gauge_background_style?.color;
-    const gaugeForegroundColor = this._config.gauge_foreground_style?.color;
 
     return html`
     <ha-card
@@ -219,68 +214,35 @@ export class ModernCircularGauge extends LitElement {
         </p>
       </div>
       ` : nothing}
-      <div class="container"
-        style=${styleMap({ "--gauge-color": gaugeForegroundColor && gaugeForegroundColor != "adaptive" ? gaugeForegroundColor : computeSegments(numberState, segments, this._config.smooth_segments, this) })}
+      <div
+        class="container${classMap({ "dual-gauge": typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner" })}"
+        style=${styleMap({"--gauge-color": this._config.gauge_foreground_style?.color && this._config.gauge_foreground_style?.color != "adaptive" ? this._config.gauge_foreground_style?.color : computeSegments(numberState, this._config.segments, this._config.smoothSegments, this)})}
       >
-        <svg viewBox="-50 -50 100 100" preserveAspectRatio="xMidYMid"
-          overflow="visible"
-          style=${styleMap({ "--gauge-stroke-width": this._config.gauge_foreground_style?.width ? `${this._config.gauge_foreground_style?.width}px` : undefined,
-            "--inner-gauge-stroke-width": typeof this._config.secondary == "object" ? this._config.secondary?.gauge_foreground_style?.width ? `${this._config.secondary?.gauge_foreground_style?.width}px` : undefined : undefined })}
-          class=${classMap({ "dual-gauge": typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner" })}
-        >
-          <g transform="rotate(${ROTATE_ANGLE})">
-            <defs>
-              ${needle ? svg`
-              <mask id="needle-border-mask">
-                <rect x="-60" y="-60" width="120" height="120" fill="white"/>
-                ${renderPath("needle-border", path, needle, styleMap({ "stroke": "black" }))}
-              </mask>`
-               : nothing}
-              <mask id="gradient-path">
-                ${renderPath("arc", path, undefined, styleMap({ "stroke": "white", "stroke-width": this._config.gauge_background_style?.width ? `${this._config.gauge_background_style?.width}px` : undefined }))}
-              </mask>
-              <mask id="gradient-current-path">
-                ${current ? renderPath("arc current", path, current, styleMap({ "stroke": "white", "visibility": numberState <= min && min >= 0 ? "hidden" : "visible" })) : nothing}
-              </mask>
-              <mask id="gradient-inner-path">
-                ${renderPath("arc", innerPath, undefined, styleMap({ "stroke": "white", "stroke-width": typeof this._config.secondary == "object" ? this._config.secondary?.gauge_background_style?.width ? `${this._config.secondary?.gauge_background_style?.width}px` 
-                  : 'var(--inner-gauge-stroke-width)' : 'var(--inner-gauge-stroke-width)' }))}
-              </mask>
-              <mask id="gradient-tertiary-path">
-                ${renderPath("arc", TERTIARY_PATH, undefined, styleMap({ "stroke": "white", "stroke-width": typeof this._config.tertiary == "object" ? this._config.tertiary?.gauge_background_style?.width ? `${this._config.tertiary?.gauge_background_style?.width}px`
-                  : 'var(--inner-gauge-stroke-width)' : 'var(--inner-gauge-stroke-width)' }))}
-              </mask>
-            </defs>
-            <g class="background" mask=${ifDefined(needle ? "url(#needle-border-mask)" : undefined)} style=${styleMap({ "opacity": this._config.gauge_background_style?.opacity,
-              "--gauge-stroke-width": this._config.gauge_background_style?.width ? `${this._config.gauge_background_style?.width}px` : undefined })}>
-              ${renderPath("arc clear", path, undefined, styleMap({ "stroke": gaugeBackgroundColor && gaugeBackgroundColor != "adaptive" ? gaugeBackgroundColor : undefined }))}
-              ${this._config.segments && (needle || this._config.gauge_background_style?.color == "adaptive") ? svg`
-              <g class="segments" mask=${ifDefined(this._config.smooth_segments ? "url(#gradient-path)" : undefined)}>
-                ${renderColorSegments(segments, min, max, RADIUS, this._config?.smooth_segments)}
-              </g>`
-              : nothing
-              }
-            </g>
-            ${current ? gaugeForegroundColor == "adaptive" ? svg`
-              <g class="foreground-segments" mask="url(#gradient-current-path)" style=${styleMap({ "opacity": this._config.gauge_foreground_style?.opacity })}>
-                ${renderColorSegments(segments, min, max, RADIUS, this._config?.smooth_segments)}
-              </g>
-              ` : renderPath("arc current", path, current, styleMap({ "visibility": numberState <= min && min >= 0 ? "hidden" : "visible", "opacity": this._config.gauge_foreground_style?.opacity })) : nothing}
-            ${typeof this._config.secondary != "string" ? 
-              this._config.secondary?.show_gauge == "outter" ? this._renderOutterSecondary()
-              : this._config.secondary?.show_gauge == "inner" ? this._renderInnerGauge()
-              : nothing
-              : nothing}
-            ${typeof this._config.tertiary != "string" ? 
-              this._config.tertiary?.show_gauge == "inner" || this._config.tertiary?.show_gauge == "outter" ? this._renderTertiaryRing()
-              : nothing
-              : nothing
-            }
-            ${needle ? svg`
-              ${renderPath("needle", path, needle)}
-              ` : nothing}
-          </g>
-        </svg>
+        <div class="gauge-container">
+          <modern-circular-gauge-element
+            .min=${min}
+            .max=${max}
+            .value=${numberState}
+            .radius=${RADIUS}
+            .maxAngle=${MAX_ANGLE}
+            .segments=${segments}
+            .smoothSegments=${this._config.smooth_segments}
+            .foregroundStyle=${this._config.gauge_foreground_style}
+            .backgroundStyle=${this._config.gauge_background_style}
+            .needle=${this._config.needle}
+            .startFromZero=${this._config.start_from_zero}
+          ></modern-circular-gauge-element>
+          ${typeof this._config.secondary != "string" ? 
+          this._config.secondary?.show_gauge == "outter" || this._config.secondary?.show_gauge == "inner" ?
+          this._renderSecondaryGauge()
+          : nothing
+          : nothing}
+          ${typeof this._config.tertiary != "string" ? 
+          this._config.tertiary?.show_gauge == "outter" || this._config.tertiary?.show_gauge == "inner" ?
+          this._renderTertiaryRing()
+          : nothing
+          : nothing}
+        </div>
         <svg class="state" overflow="visible" viewBox="-50 -50 100 100">
           ${this._config.show_state ? svg`
           <text
@@ -378,6 +340,7 @@ export class ModernCircularGauge extends LitElement {
               ` : html`<ha-svg-icon class="warning-icon" .path=${icon}></ha-svg-icon>`}
           </div>
         </div>
+      </div>
       </ha-card>
       `;
   }
@@ -399,159 +362,154 @@ export class ModernCircularGauge extends LitElement {
     return `${initialSize}px`;
   }
 
-  private _renderGaugeRing(gaugeName: string, state: string, min: number, max: number, d: string, radius: number, needle?: boolean , segments?: SegmentsConfig[], foregroundStyle?: GaugeElementConfig, backgroundStyle?: GaugeElementConfig): TemplateResult {
-    const numberState = Number(state);
-
-    if (state === "unavailable") {
-      return svg`
-      <g class="${gaugeName}">
-        ${renderPath("arc clear", d)}
-      </g>
-      `;
-    }
-
-    if (isNaN(numberState)) {
-      return svg``;
-    }
-
-    const current = needle ? undefined : currentDashArc(numberState, min, max, radius, this._config?.start_from_zero);
-    const needleArc = needle ? strokeDashArc(numberState, numberState, min, max, radius) : undefined;
-
-    return svg`
-    <g class="${gaugeName}"
-      style=${styleMap({ "--gauge-color": foregroundStyle?.color && foregroundStyle.color != "adaptive" ? foregroundStyle.color : computeSegments(numberState, segments, this._config?.smooth_segments, this) })}
-    >
-      ${needleArc ? svg`
-      <mask id="needle-border-${gaugeName}-mask">
-        <rect x="-60" y="-60" width="120" height="120" fill="white"/>
-        ${renderPath("needle-border", path, needleArc, styleMap({ "stroke": "black" }))}
-      </mask>`
-        : nothing}
-      <mask id="gradient-current-${gaugeName}-path">
-        ${current ? renderPath("arc current", d, current, styleMap({ "stroke": "white", "visibility": numberState <= min && min >= 0 ? "hidden" : "visible" })) : nothing}
-      </mask>
-      <g class="background" mask=${ifDefined(needleArc ? `url(#needle-border-${gaugeName}-mask)` : undefined)} style=${styleMap({ "opacity": backgroundStyle?.opacity,
-        "--gauge-stroke-width": backgroundStyle?.width ? `${backgroundStyle?.width}px` : undefined })}
-      >
-        ${renderPath("arc clear", d, undefined, styleMap({ "stroke": backgroundStyle?.color && backgroundStyle?.color != "adaptive" ? backgroundStyle?.color : undefined }))}
-        ${segments && (needleArc || backgroundStyle?.color == "adaptive") ? svg`
-        <g class="segments" mask=${ifDefined(this._config?.smooth_segments ? `url(#gradient-${gaugeName}-path)` : undefined)}>
-          ${renderColorSegments(segments, min, max, radius, this._config?.smooth_segments)}
-        </g>`
-        : nothing
-        }
-      </g>
-      ${current ? foregroundStyle?.color == "adaptive" && segments ? svg`
-        <g class="foreground-segments" mask="url(#gradient-current-${gaugeName}-path)" style=${styleMap({ "opacity": foregroundStyle?.opacity })}>
-          ${renderColorSegments(segments, min, max, radius, this._config?.smooth_segments)}
-        </g>
-      ` : renderPath("arc current", d, current, styleMap({ "visibility": numberState <= min && min >= 0 ? "hidden" : "visible", "opacity": foregroundStyle?.opacity })) : nothing}
-      ${needleArc ? svg`
-        ${renderPath("needle", d, needleArc)}
-        ` : nothing}
-    </g>
-    `;
-  }
-
   private _renderTertiaryRing(): TemplateResult {
     const tertiaryObj = this._config?.tertiary as TertiaryEntity;
     const stateObj = this.hass.states[tertiaryObj.entity || ""];
     const templatedState = this._templateResults?.tertiaryEntity?.result;
     
     if (!tertiaryObj) {
-      return svg``;
+      return html``;
     }
 
     if (tertiaryObj.show_gauge == "inner") {
       if (!stateObj && templatedState === undefined) {
-        return svg`
-        <g class="tertiary">
-          ${renderPath("arc clear", TERTIARY_PATH)}
-        </g>
+        return html`
+        <modern-circular-gauge-element
+          class="tertiary"
+          .radius=${TERTIARY_RADIUS}
+          .maxAngle=${MAX_ANGLE}
+        ></modern-circular-gauge-element>
         `;
       }
 
       const min = Number(this._templateResults?.tertiaryMin?.result ?? tertiaryObj.min) || DEFAULT_MIN;
       const max = Number(this._templateResults?.tertiaryMax?.result ?? tertiaryObj.max) || DEFAULT_MAX;
       const segments = (this._templateResults?.tertiarySegments as unknown) as SegmentsConfig[] ?? tertiaryObj.segments;
+      const numberState = Number(templatedState ?? stateObj.state);
 
-      return this._renderGaugeRing("tertiary", templatedState ?? stateObj.state, min, max, TERTIARY_PATH, TERTIARY_RADIUS, tertiaryObj.needle, segments, tertiaryObj.gauge_foreground_style, tertiaryObj.gauge_background_style);
+      return html`
+      <modern-circular-gauge-element
+        class="tertiary"
+        .min=${min}
+        .max=${max}
+        .value=${numberState}
+        .radius=${TERTIARY_RADIUS}
+        .maxAngle=${MAX_ANGLE}
+        .segments=${segments}
+        .smoothSegments=${this._config?.smooth_segments}
+        .foregroundStyle=${tertiaryObj?.gauge_foreground_style}
+        .backgroundStyle=${tertiaryObj?.gauge_background_style}
+        .needle=${tertiaryObj?.needle}
+        .startFromZero=${tertiaryObj?.start_from_zero}
+      ></modern-circular-gauge-element>
+      `;
     } else {
       if (!stateObj && templatedState === undefined) {
-        return svg``;
+        return html``;
       }
 
       const numberState = Number(templatedState ?? stateObj.state);
 
       if (stateObj?.state === "unavailable" && templatedState) {
-        return svg``;
+        return html``;
       }
   
       if (isNaN(numberState)) {
-        return svg``;
+        return html``;
       }
   
       const min = Number(this._templateResults?.min?.result ?? this._config?.min) || DEFAULT_MIN; 
       const max = Number(this._templateResults?.max?.result ?? this._config?.max) || DEFAULT_MAX;
   
-      const current = strokeDashArc(numberState, numberState, min, max, RADIUS);
-  
-      return svg`
-      ${!tertiaryObj.gauge_foreground_style?.color ? renderPath("dot border tertiary", path, current, styleMap({ "opacity": tertiaryObj.gauge_foreground_style?.opacity ?? 1, "stroke": tertiaryObj.gauge_foreground_style?.color, "stroke-width": tertiaryObj.gauge_foreground_style?.width })) : nothing}
-      ${renderPath("dot", path, current, styleMap({ "opacity": tertiaryObj.gauge_foreground_style?.opacity ?? 1, "stroke": tertiaryObj.gauge_foreground_style?.color, "stroke-width": tertiaryObj.gauge_foreground_style?.width }))}
+      return html`
+      <modern-circular-gauge-element
+        class="tertiary"
+        .min=${min}
+        .max=${max}
+        .value=${numberState}
+        .radius=${RADIUS}
+        .maxAngle=${MAX_ANGLE}
+        .foregroundStyle=${tertiaryObj?.gauge_foreground_style}
+        .backgroundStyle=${tertiaryObj?.gauge_background_style}
+        .outter=${true}
+      ></modern-circular-gauge-element>
       `;
     }
   }
 
-  private _renderInnerGauge(): TemplateResult {
+  private _renderSecondaryGauge(): TemplateResult {
     const secondaryObj = this._config?.secondary as SecondaryEntity;
     const stateObj = this.hass.states[secondaryObj.entity || ""];
     const templatedState = this._templateResults?.secondaryEntity?.result;
 
+    if (!secondaryObj) {
+      return html``;
+    }
     
-    if ((!stateObj || !secondaryObj) && templatedState === undefined) {
-      return svg`
-      <g class="inner">
-        ${renderPath("arc clear", innerPath)}
-      </g>
+    if (secondaryObj.show_gauge == "inner") {
+      if (!stateObj && templatedState === undefined) {
+        return html`
+        <modern-circular-gauge-element
+          class="secondary"
+          .radius=${INNER_RADIUS}
+          .maxAngle=${MAX_ANGLE}
+        ></modern-circular-gauge-element>
+        `;
+      }
+
+      const min = Number(this._templateResults?.secondaryMin?.result ?? secondaryObj.min) || DEFAULT_MIN; 
+      const max = Number(this._templateResults?.secondaryMax?.result ?? secondaryObj.max) || DEFAULT_MAX;
+      const segments = (this._templateResults?.secondarySegments as unknown) as SegmentsConfig[] ?? secondaryObj.segments;
+      const numberState = Number(templatedState ?? stateObj.state);
+
+      return html`
+      <modern-circular-gauge-element
+        class="secondary"
+        .min=${min}
+        .max=${max}
+        .value=${numberState}
+        .radius=${INNER_RADIUS}
+        .maxAngle=${MAX_ANGLE}
+        .segments=${segments}
+        .smoothSegments=${this._config?.smooth_segments}
+        .foregroundStyle=${secondaryObj?.gauge_foreground_style}
+        .backgroundStyle=${secondaryObj?.gauge_background_style}
+        .needle=${secondaryObj?.needle}
+        .startFromZero=${secondaryObj.start_from_zero}
+      ></modern-circular-gauge-element>
+      `;
+    } else {
+      if (!stateObj && templatedState === undefined) {
+        return html``;
+      }
+
+      const numberState = Number(templatedState ?? stateObj.state);
+
+      if (stateObj?.state === "unavailable" && templatedState) {
+        return html``;
+      }
+  
+      if (isNaN(numberState)) {
+        return html``;
+      }
+  
+      const min = Number(this._templateResults?.min?.result ?? this._config?.min) || DEFAULT_MIN; 
+      const max = Number(this._templateResults?.max?.result ?? this._config?.max) || DEFAULT_MAX;
+  
+      return html`
+      <modern-circular-gauge-element
+        class="secondary"
+        .min=${min}
+        .max=${max}
+        .value=${numberState}
+        .radius=${RADIUS}
+        .maxAngle=${MAX_ANGLE}
+        .foregroundStyle=${secondaryObj?.gauge_foreground_style}
+        .backgroundStyle=${secondaryObj?.gauge_background_style}
+        .outter=${true}
+      ></modern-circular-gauge-element>
       `;
     }
-
-    const min = Number(this._templateResults?.secondaryMin?.result ?? secondaryObj.min) || DEFAULT_MIN; 
-    const max = Number(this._templateResults?.secondaryMax?.result ?? secondaryObj.max) || DEFAULT_MAX;
-    const segments = (this._templateResults?.secondarySegments as unknown) as SegmentsConfig[] ?? secondaryObj.segments;
-
-    return this._renderGaugeRing("inner", templatedState ?? stateObj.state, min, max, innerPath, INNER_RADIUS, secondaryObj.needle, segments, secondaryObj.gauge_foreground_style, secondaryObj.gauge_background_style);
-  }
-
-  private _renderOutterSecondary(): TemplateResult {
-    const secondaryObj = this._config?.secondary as SecondaryEntity;
-    const stateObj = this.hass.states[secondaryObj.entity || ""];
-    const templatedState = this._templateResults?.secondaryEntity?.result;
-
-    if (!stateObj && templatedState === undefined) {
-      return svg``;
-    }
-
-    const numberState = Number(templatedState ?? stateObj.state);
-
-    if (stateObj?.state === "unavailable" && templatedState) {
-      return svg``;
-    }
-
-    if (isNaN(numberState)) {
-      return svg``;
-    }
-
-    const min = Number(this._templateResults?.min?.result ?? this._config?.min) || DEFAULT_MIN; 
-    const max = Number(this._templateResults?.max?.result ?? this._config?.max) || DEFAULT_MAX;
-
-    const current = strokeDashArc(numberState, numberState, min, max, RADIUS);
-
-    return svg`
-    ${!secondaryObj.gauge_foreground_style?.color ? renderPath("dot border secondary", path, current, styleMap({ "opacity": secondaryObj.gauge_foreground_style?.opacity ?? 1, "stroke-width": secondaryObj.gauge_foreground_style?.width })) : nothing}
-    ${renderPath("dot", path, current, styleMap({ "opacity": secondaryObj.gauge_foreground_style?.opacity ?? 1, "stroke": secondaryObj.gauge_foreground_style?.color, "stroke-width": secondaryObj.gauge_foreground_style?.width }))}
-    `;
   }
 
   private _renderTertiary(): TemplateResult {
@@ -1159,6 +1117,20 @@ export class ModernCircularGauge extends LitElement {
       opacity: 0.6;
     }
 
+    .gauge-container {
+      height: 100%;
+      width: 100%;
+      display: block;
+    }
+
+    modern-circular-gauge-element.secondary, modern-circular-gauge-element.tertiary {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
     svg {
       width: 100%;
       height: 100%;
@@ -1217,7 +1189,7 @@ export class ModernCircularGauge extends LitElement {
       --gauge-color: var(--gauge-tertiary-color);
     }
 
-    .dual-gauge {
+    .dual-gauge modern-circular-gauge-element {
       --gauge-stroke-width: 4px;
     }
 

--- a/src/components/modern-circular-gauge-element.ts
+++ b/src/components/modern-circular-gauge-element.ts
@@ -1,0 +1,193 @@
+import { html, LitElement, css, svg, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { DEFAULT_MAX, DEFAULT_MIN, MAX_ANGLE } from "../const";
+import { GaugeElementConfig, SegmentsConfig } from "../card/type";
+import { styleMap } from "lit/directives/style-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { svgArc, renderPath, currentDashArc, strokeDashArc, renderColorSegments, computeSegments } from "../utils/gauge";
+
+@customElement("modern-circular-gauge-element")
+export class ModernCircularGaugeElement extends LitElement {
+  @property({ type: Number }) public min = DEFAULT_MIN;
+
+  @property({ type: Number }) public max = DEFAULT_MAX;
+
+  @property({ type: Number }) public value = 0;
+
+  @property({ type: Number }) public radius = 47;
+
+  @property({ type: Number }) public maxAngle = MAX_ANGLE;
+
+  @property({ type: Array }) public segments?: SegmentsConfig[];
+
+  @property({ type: Boolean }) public smoothSegments = false;
+
+  @property({ type: Object }) public foregroundStyle?: GaugeElementConfig;
+
+  @property({ type: Object }) public backgroundStyle?: GaugeElementConfig;
+
+  @property({ type: Boolean }) public needle = false;
+
+  @property({ type: Boolean }) public startFromZero = false;
+
+  @property({ type: Boolean }) public outter = false;
+
+  @state() private _updated = false;
+
+  @state() private _path?: string;
+
+  @state() private _rotateAngle?: number;
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    if (!this._updated) {
+      this._path = svgArc({
+        x: 0,
+        y: 0,
+        start: 0,
+        end: this.maxAngle,
+        r: this.radius,
+      });
+      this._rotateAngle = 360 - this.maxAngle / 2 - 90;
+      this._updated = true;
+    }
+  }
+
+  protected render() {
+    if (!this._path) {
+      return nothing;
+    }
+
+    if (this.outter)
+    {
+      const current = strokeDashArc(this.value, this.value, this.min, this.max, this.radius);
+
+      return html`
+      <svg viewBox="-50 -50 100 100" preserveAspectRatio="xMidYMid"
+        overflow="visible"
+        style=${styleMap({ "--gauge-stroke-width": this.foregroundStyle?.width ? `${this.foregroundStyle?.width}px` : undefined,
+        "--gauge-color": this.foregroundStyle?.color && this.foregroundStyle?.color != "adaptive" ? this.foregroundStyle?.color : computeSegments(this.value, this.segments, this.smoothSegments, this) })}
+      >
+        <g transform="rotate(${this._rotateAngle})">
+          ${!this.foregroundStyle?.color ? renderPath("dot border", this._path, current, styleMap({ "opacity": this.foregroundStyle?.opacity ?? 1, "stroke-width": this.foregroundStyle?.width })) : nothing}
+          ${renderPath("dot", this._path, current, styleMap({ "opacity": this.foregroundStyle?.opacity ?? 1, "stroke": this.foregroundStyle?.color, "stroke-width": this.foregroundStyle?.width }))}
+        </g>
+      </svg>
+      `
+    } else {
+      const current = this.needle ? undefined : currentDashArc(this.value, this.min, this.max, this.radius, this.startFromZero);
+      const needle = this.needle ? strokeDashArc(this.value, this.value, this.min, this.max, this.radius) : undefined;
+      
+      return html`
+        <svg viewBox="-50 -50 100 100" preserveAspectRatio="xMidYMid"
+          overflow="visible"
+          style=${styleMap({ "--gauge-stroke-width": this.foregroundStyle?.width ? `${this.foregroundStyle?.width}px` : undefined,
+          "--gauge-color": this.foregroundStyle?.color && this.foregroundStyle?.color != "adaptive" ? this.foregroundStyle?.color : computeSegments(this.value, this.segments, this.smoothSegments, this) })}
+        >
+          <g transform="rotate(${this._rotateAngle})">
+            <defs>
+              <mask id="gradient-path">
+                ${renderPath("arc", this._path, undefined, styleMap({ "stroke": "white", "stroke-width": this.backgroundStyle?.width ? `${this.backgroundStyle?.width}px` : undefined }))}
+              </mask>
+              <mask id="gradient-current-path">
+                ${current ? renderPath("arc current", this._path, current, styleMap({ "stroke": "white", "visibility": this.value <= this.min && this.min >= 0 ? "hidden" : "visible" })) : nothing}
+              </mask>
+            </defs>
+            <g class="background" style=${styleMap({ "opacity": this.backgroundStyle?.opacity,
+              "--gauge-stroke-width": this.backgroundStyle?.width ? `${this.backgroundStyle?.width}px` : undefined })}>
+              ${renderPath("arc clear", this._path, undefined, styleMap({ "stroke": this.backgroundStyle?.color && this.backgroundStyle.color != "adaptive" ? this.backgroundStyle.color : undefined }))}
+              ${this.segments && (needle || this.backgroundStyle?.color == "adaptive") ? svg`
+              <g class="segments" mask=${ifDefined(this.smoothSegments ? "url(#gradient-path)" : undefined)}>
+                ${renderColorSegments(this.segments, this.min, this.max, this.radius, this.smoothSegments)}
+              </g>`
+              : nothing
+              }
+            </g>
+            ${current ? this.foregroundStyle?.color == "adaptive" && this.segments ? svg`
+            <g class="foreground-segments" mask="url(#gradient-current-path)" style=${styleMap({ "opacity": this.foregroundStyle?.opacity })}>
+              ${renderColorSegments(this.segments, this.min, this.max, this.radius, this.smoothSegments)}
+            </g>
+            ` : renderPath("arc current", this._path, current, styleMap({ "visibility": this.value <= this.min && this.min >= 0 ? "hidden" : "visible", "opacity": this.foregroundStyle?.opacity }))
+            : nothing}
+            ${needle ? svg`
+            ${renderPath("needle-border", this._path, needle)}
+            ${renderPath("needle", this._path, needle)}
+            ` : nothing}
+          </g>
+        </svg>
+      `;
+    }
+  }
+
+  static get styles() {
+    return css`
+    :host {
+      --gauge-primary-color: var(--light-blue-color);
+
+      --gauge-color: var(--gauge-primary-color);
+      --gauge-stroke-width: 6px;
+    }
+    svg {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+    g {
+      fill: none;
+    }
+    .arc {
+      fill: none;
+      stroke-linecap: round;
+      stroke-width: var(--gauge-stroke-width);
+    }
+
+    .arc.clear {
+      stroke: var(--primary-background-color);
+    }
+
+    .arc.current {
+      stroke: var(--gauge-color);
+      transition: all 1s ease 0s;
+    }
+
+    .segment {
+      fill: none;
+      stroke-width: var(--gauge-stroke-width);
+      filter: brightness(100%);
+    }
+
+    .segments {
+      opacity: 0.35;
+    }
+
+    .needle {
+      fill: none;
+      stroke-linecap: round;
+      stroke-width: var(--gauge-stroke-width);
+      stroke: var(--gauge-color);
+      transition: all 1s ease 0s;
+    }
+
+    .needle-border {
+      fill: none;
+      stroke-linecap: round;
+      stroke-width: calc(var(--gauge-stroke-width) + 2px);
+      stroke: var(--card-background-color);
+      transition: all 1s ease 0s, stroke 0.3s ease-out;
+    }
+    
+    .dot {
+      fill: none;
+      stroke-linecap: round;
+      stroke-width: calc(var(--gauge-stroke-width) / 2);
+      stroke: var(--primary-text-color);
+      transition: all 1s ease 0s;
+    }
+
+    .dot.border {
+      stroke: var(--gauge-color);
+      stroke-width: var(--gauge-stroke-width);
+    }
+    `;
+  }
+}

--- a/src/components/modern-circular-gauge-element.ts
+++ b/src/components/modern-circular-gauge-element.ts
@@ -164,11 +164,10 @@ export class ModernCircularGaugeElement extends LitElement {
     .segment {
       fill: none;
       stroke-width: var(--gauge-stroke-width);
-      filter: brightness(100%);
     }
 
     .segments {
-      opacity: 0.35;
+      opacity: 0.45;
     }
 
     .needle {

--- a/src/components/modern-circular-gauge-element.ts
+++ b/src/components/modern-circular-gauge-element.ts
@@ -86,6 +86,18 @@ export class ModernCircularGaugeElement extends LitElement {
         >
           <g transform="rotate(${this._rotateAngle})">
             <defs>
+              <mask id="needle-border-mask">
+                <rect x="-60" y="-60" width="120" height="120" fill="white"/>
+                ${needle ? svg`
+                <path
+                  class="needle-border"
+                  d=${this._path}
+                  stroke-dasharray="${needle[0]}"
+                  stroke-dashoffset="${needle[1]}"
+                  stroke="black"
+                />
+                ` : nothing}
+              </mask>
               <mask id="gradient-path">
                 ${renderPath("arc", this._path, undefined, styleMap({ "stroke": "white", "stroke-width": this.backgroundStyle?.width ? `${this.backgroundStyle?.width}px` : undefined }))}
               </mask>
@@ -93,7 +105,7 @@ export class ModernCircularGaugeElement extends LitElement {
                 ${current ? renderPath("arc current", this._path, current, styleMap({ "stroke": "white", "visibility": this.value <= this.min && this.min >= 0 ? "hidden" : "visible" })) : nothing}
               </mask>
             </defs>
-            <g class="background" style=${styleMap({ "opacity": this.backgroundStyle?.opacity,
+            <g class="background" mask=${ifDefined(needle ? "url(#needle-border-mask)" : undefined)} style=${styleMap({ "opacity": this.backgroundStyle?.opacity,
               "--gauge-stroke-width": this.backgroundStyle?.width ? `${this.backgroundStyle?.width}px` : undefined })}>
               ${renderPath("arc clear", this._path, undefined, styleMap({ "stroke": this.backgroundStyle?.color && this.backgroundStyle.color != "adaptive" ? this.backgroundStyle.color : undefined }))}
               ${this.segments && (needle || this.backgroundStyle?.color == "adaptive") ? svg`
@@ -110,7 +122,6 @@ export class ModernCircularGaugeElement extends LitElement {
             ` : renderPath("arc current", this._path, current, styleMap({ "visibility": this.value <= this.min && this.min >= 0 ? "hidden" : "visible", "opacity": this.foregroundStyle?.opacity }))
             : nothing}
             ${needle ? svg`
-            ${renderPath("needle-border", this._path, needle)}
             ${renderPath("needle", this._path, needle)}
             ` : nothing}
           </g>
@@ -171,7 +182,7 @@ export class ModernCircularGaugeElement extends LitElement {
     .needle-border {
       fill: none;
       stroke-linecap: round;
-      stroke-width: calc(var(--gauge-stroke-width) + 2px);
+      stroke-width: calc(var(--gauge-stroke-width) + 4px);
       stroke: var(--card-background-color);
       transition: all 1s ease 0s, stroke 0.3s ease-out;
     }

--- a/src/components/modern-circular-gauge-element.ts
+++ b/src/components/modern-circular-gauge-element.ts
@@ -183,7 +183,6 @@ export class ModernCircularGaugeElement extends LitElement {
       fill: none;
       stroke-linecap: round;
       stroke-width: calc(var(--gauge-stroke-width) + 4px);
-      stroke: var(--card-background-color);
       transition: all 1s ease 0s, stroke 0.3s ease-out;
     }
     


### PR DESCRIPTION
Increased needle border to improve the gauge line and needle separation for better readability.
Needle border now support transparent card themes.
Tuned up color segments opacity.

Before:
![before](https://github.com/user-attachments/assets/c98ed885-542f-4543-a4a0-c16e3bdbaf33)
After:
![after](https://github.com/user-attachments/assets/df43fc26-224b-44e9-9822-3daf8e5a9fdc)
