### PR TITLE
feat: adjustable gauge radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | state_font_size | `number` | `24` | Initial state size in px
 | header_font_size | `number` | `14` | Gauge header font size in px
 | header_offset | `number` | `0` | Gauge header vertical offset in px
+| gauge_radius | `number` | `47` | Gauge radius
 | gauge_background_style | `object` | Optional | Gauge background style, see [gauge element style object](#gauge-element-style-object)
 | gauge_foreground_style | `object` | Optional | Gauge foreground style, see [gauge element style object](#gauge-element-style-object)
 | segments | `list` | | Color segments list, see [color segments object](#color-segment-object)
@@ -133,6 +134,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_unit | `boolean` | `true` | Show secondary unit
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | state_font_size | `number` | `10` or `24` | State size in px
+| gauge_radius | `number` | `42` | Gauge radius
 | gauge_background_style | `object` | Optional | Gauge background style, see [gauge element style object](#gauge-element-style-object)
 | gauge_foreground_style | `object` | Optional | Gauge foreground style, see [gauge element style object](#gauge-element-style-object)
 | needle | `boolean` | `false` |
@@ -151,6 +153,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 | show_unit | `boolean` | `true` | Show secondary unit
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | state_font_size | `number` | `10` | State size in px
+| gauge_radius | `number` | `37` | Gauge radius
 | gauge_background_style | `object` | Optional | Gauge background style, see [gauge element style object](#gauge-element-style-object)
 | gauge_foreground_style | `object` | Optional | Gauge foreground style, see [gauge element style object](#gauge-element-style-object)
 | needle | `boolean` | `false` |

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -228,7 +228,7 @@ export class ModernCircularGauge extends LitElement {
             .min=${min}
             .max=${max}
             .value=${numberState}
-            .radius=${RADIUS}
+            .radius=${this._config.gauge_radius ?? RADIUS}
             .maxAngle=${MAX_ANGLE}
             .segments=${segments}
             .smoothSegments=${this._config.smooth_segments}
@@ -388,19 +388,19 @@ export class ModernCircularGauge extends LitElement {
 
     if (typeof this._config?.secondary != "string") {
       if (this._config?.secondary?.show_gauge == "inner") {
-        const gauge = { radius: INNER_RADIUS, width: this._config.secondary.gauge_foreground_style?.width ?? 4 };
+        const gauge = { radius: this._config.secondary.gauge_radius ?? INNER_RADIUS, width: this._config.secondary.gauge_foreground_style?.width ?? 4 };
         gauges.push(gauge)
       }
     }
 
     if (typeof this._config?.tertiary != "string") {
       if (this._config?.tertiary?.show_gauge == "inner") {
-        const gauge = { radius: TERTIARY_RADIUS, width: this._config.tertiary.gauge_foreground_style?.width ?? 4 };
+        const gauge = { radius: this._config.tertiary.gauge_radius ?? TERTIARY_RADIUS, width: this._config.tertiary.gauge_foreground_style?.width ?? 4 };
         gauges.push(gauge)
       }
     }
 
-    gauges.push({ radius: RADIUS, width: this._config?.gauge_foreground_style?.width ?? (gauges.length > 1 ? 4 : 6) });
+    gauges.push({ radius: this._config?.gauge_radius ?? RADIUS, width: this._config?.gauge_foreground_style?.width ?? (gauges.length > 1 ? 4 : 6) });
     const gauge = gauges.reduce((r, e) => r.radius < e.radius ? r : e);
 
     return (gauge.radius - gauge.width) * 2;
@@ -437,7 +437,7 @@ export class ModernCircularGauge extends LitElement {
         .min=${min}
         .max=${max}
         .value=${numberState}
-        .radius=${TERTIARY_RADIUS}
+        .radius=${tertiaryObj.gauge_radius ?? TERTIARY_RADIUS}
         .maxAngle=${MAX_ANGLE}
         .segments=${segments}
         .smoothSegments=${this._config?.smooth_segments}
@@ -471,7 +471,7 @@ export class ModernCircularGauge extends LitElement {
         .min=${min}
         .max=${max}
         .value=${numberState}
-        .radius=${RADIUS}
+        .radius=${this._config?.gauge_radius ?? RADIUS}
         .maxAngle=${MAX_ANGLE}
         .foregroundStyle=${tertiaryObj?.gauge_foreground_style}
         .backgroundStyle=${tertiaryObj?.gauge_background_style}
@@ -512,7 +512,7 @@ export class ModernCircularGauge extends LitElement {
         .min=${min}
         .max=${max}
         .value=${numberState}
-        .radius=${INNER_RADIUS}
+        .radius=${secondaryObj.gauge_radius ?? INNER_RADIUS}
         .maxAngle=${MAX_ANGLE}
         .segments=${segments}
         .smoothSegments=${this._config?.smooth_segments}
@@ -546,7 +546,7 @@ export class ModernCircularGauge extends LitElement {
         .min=${min}
         .max=${max}
         .value=${numberState}
-        .radius=${RADIUS}
+        .radius=${this._config?.gauge_radius ?? RADIUS}
         .maxAngle=${MAX_ANGLE}
         .foregroundStyle=${secondaryObj?.gauge_foreground_style}
         .backgroundStyle=${secondaryObj?.gauge_background_style}

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -18,6 +18,7 @@ export interface BaseEntityConfig {
     state_text?: string;
     state_font_size?: number;
     start_from_zero?: boolean;
+    gauge_radius?: number;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;
     adaptive_state_color?: boolean;
@@ -69,6 +70,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     header_offset?: number;
     start_from_zero?: boolean;
     gauge_width?: number;
+    gauge_radius?: number;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;
     segments?: SegmentsConfig[];

--- a/src/components/modern-circular-gauge-element.ts
+++ b/src/components/modern-circular-gauge-element.ts
@@ -87,7 +87,7 @@ export class ModernCircularGaugeElement extends LitElement {
           <g transform="rotate(${this._rotateAngle})">
             <defs>
               <mask id="needle-border-mask">
-                <rect x="-60" y="-60" width="120" height="120" fill="white"/>
+                <rect x="-70" y="-70" width="140" height="140" fill="white"/>
                 ${needle ? svg`
                 <path
                   class="needle-border"

--- a/src/utils/gauge.ts
+++ b/src/utils/gauge.ts
@@ -136,8 +136,8 @@ export function renderSegmentsGradient(segments: SegmentsConfig[], min: number, 
       gradient += `${color} ${angle}deg${index != sortedSegments.length - 1 ? "," : ""}`;
     });
     return [svg`
-      <foreignObject x="-50" y="-50" width="100%" height="100%" transform="rotate(45)">
-        <div style="width: 100px; height: 100px; background-image: conic-gradient(${gradient})">
+      <foreignObject x="-50" y="-50" width="100%" height="100%" overflow="visible" transform="rotate(45)">
+        <div style="width: 110px; height: 110px; margin-left: -5px; margin-top: -5px; background-image: conic-gradient(${gradient})">
         </div>
       </foreignObject>
     `];


### PR DESCRIPTION
Adds configurable gauge radius which in short allow user to pack all gauges close together or move them so innermost is now outtermost.

![brave_9N9p43TnJ7](https://github.com/user-attachments/assets/68aa56ea-2c3f-495f-a6d7-fbffe1a5dc13)![brave_Ig9XFB2E3H](https://github.com/user-attachments/assets/2c2419c3-f1dc-4888-b63f-0d0ab3885b5a)

