### PR TITLE
feat: label support for small secondary and tertiary state

### DIFF
--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -365,6 +365,8 @@ export class ModernCircularGauge extends LitElement {
     }
 
     const value = Number(templatedState ?? stateObj.state);
+    const iconCenter = !(this._config?.show_state ?? false) && (this._config?.show_icon ?? true);
+    const secondaryHasLabel = typeof this._config?.secondary != "string" && this._config?.secondary?.label;
 
     return html`
     <svg class="icon-container" viewBox="-50 -50 100 100" preserveAspectRatio="xMidYMid">
@@ -372,7 +374,8 @@ export class ModernCircularGauge extends LitElement {
         <div class="icon-wrapper" style="width: 100px; height: 100px;">
           <ha-state-icon
             class=${classMap({ "adaptive": !!this._config?.adaptive_icon_color, "big": !this._hasSecondary })}
-            style=${styleMap({ "color": gaugeForegroundStyle?.color && gaugeForegroundStyle.color != "adaptive" ? gaugeForegroundStyle.color : computeSegments(value, segments, this._config?.smooth_segments, this) })}
+            style=${styleMap({ "color": gaugeForegroundStyle?.color && gaugeForegroundStyle.color != "adaptive" ? gaugeForegroundStyle.color : computeSegments(value, segments, this._config?.smooth_segments, this),
+              "bottom": secondaryHasLabel && !iconCenter ? "9%" : undefined })}
             .hass=${this.hass}
             .stateObj=${stateObj}
             .icon=${iconOverride}

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -627,7 +627,7 @@ export class ModernCircularGauge extends LitElement {
       .unit=${unit}
       .verticalOffset=${secondary.state_size == "big" ? 14 : iconCenter ? 22 : 17}
       .small=${secondary.state_size != "big"}
-      .label=${secondary.state_size == "big" ? secondary.label : ""}
+      .label=${secondary.label}
       .stateMargin=${this._stateMargin}
       .labelFontSize=${secondary.label_font_size}
       .showUnit=${secondary.show_unit ?? true}
@@ -702,6 +702,7 @@ export class ModernCircularGauge extends LitElement {
       .verticalOffset=${-19}
       .stateMargin=${this._stateMargin}
       .showUnit=${tertiary.show_unit ?? true}
+      .label=${tertiary.label}
       small
     ></modern-circular-gauge-state>
     `;

--- a/src/components/modern-circular-gauge-state.ts
+++ b/src/components/modern-circular-gauge-state.ts
@@ -86,16 +86,17 @@ export class ModernCircularGaugeState extends LitElement {
     }
 
     const state = this._computeState();
+    const verticalOffset = this.verticalOffset ?? 0;
 
     return html`
     <svg class="state ${classMap({ "small": this.small })}" overflow="visible" viewBox="-50 -50 100 100">
-      <text x="0" y=${this.verticalOffset} class="value">
+      <text x="0" y=${verticalOffset} class="value">
         ${state}
         ${this.showUnit ? svg`
         <tspan class="unit" dx=${this.small ? 0 : -4} dy=${this.small ? 0 : -6}>${this.unit}</tspan>
         ` : nothing}
       </text>
-      <text class="state-label" style=${styleMap({ "font-size": this.labelFontSize ? `${this.labelFontSize}px` : undefined })} dy=${(this.verticalOffset ?? 0) + 15}>
+      <text class="state-label" style=${styleMap({ "font-size": this.labelFontSize ? `${this.labelFontSize}px` : undefined })} y=${verticalOffset + (this.small ? (9 * Math.sign(verticalOffset)) : 13)}>
         ${this.label}
       </text>
     </svg>
@@ -151,6 +152,7 @@ export class ModernCircularGaugeState extends LitElement {
     .state-label {
       font-size: 0.49em;
       fill: var(--secondary-text-color);
+      dominant-baseline: middle;
     }
     `;
   }


### PR DESCRIPTION
Adds labels for small secondary and tertiary state, previously label were displayed only when secondary `state_size` was set to `big`.
![card](https://github.com/user-attachments/assets/338cbbbf-3d0d-4511-8d8a-6836a5be2fa9)
