### PR TITLE
fix: incorrect header position in warning card

### DIFF
--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -277,7 +277,7 @@ export class ModernCircularGauge extends LitElement {
     return html`
       <ha-card
       class="${classMap({
-        "flex-column-reverse": this._config?.header_position == "bottom",
+        "flex-column-reverse": this._config?.header_position == "top",
         "action": this._hasCardAction() && stateObj !== undefined
       })}"
       @action=${ifDefined(stateObj ? this._handleAction : undefined)}


### PR DESCRIPTION
Fixes incorrect header position in warning card i.e. when entity is not found or unavailable. Header position config was treated in reverse so top option was treated as bottom and vice-versa.