### PR TITLE
fix: corrected spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 |------|:----:|:-------:|:------------|
 | entity | `string` | Optional | Secondary entity. May contain templates
 | unit | `string` | Optional | Custom unit
-| show_gauge | `none`, `inner`, `outter` | `none` | Display secondary info as dot on main gauge or on inner gauge
+| show_gauge | `none`, `inner`, `outer` | `none` | Display secondary info as dot on main gauge or on inner gauge
 | min | `number` | Optional | Minimum inner gauge value. May contain templates
 | max | `number` | Optional | Maximum inner gauge value. May contain templates
 | label | `string` | Optional | Label under the state
@@ -148,7 +148,7 @@ Templates are supported on selected options, configurable only via `yaml`.
 |------|:----:|:-------:|:------------|
 | entity | `string` | Optional | Secondary entity. May contain templates
 | unit | `string` | Optional | Custom unit
-| show_gauge | `none`, `inner`, `outter` | `none` | Display secondary info as dot on main gauge or on inner gauge
+| show_gauge | `none`, `inner`, `outer` | `none` | Display secondary info as dot on main gauge or on inner gauge
 | min | `number` | Optional | Minimum inner gauge value. May contain templates
 | max | `number` | Optional | Maximum inner gauge value. May contain templates
 | label | `string` | Optional | Label above the state

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -10,7 +10,7 @@ export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
         options: [
           { value: "none", label: "None" },
           { value: "inner", label: "Inner gauge" },
-          { value: "outter", label: "Outter gauge" },
+          { value: "outer", label: "Outer gauge" },
         ],
         mode: "dropdown",
       }},

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -51,7 +51,7 @@ const TERTIARY_PATH = svgArc({
 
 registerCustomCard({
   type: "modern-circular-gauge",
-  name: "Modern Cicular Gauge",
+  name: "Modern Circular Gauge",
   description: "Modern circular gauge",
 });
 
@@ -238,12 +238,12 @@ export class ModernCircularGauge extends LitElement {
             .startFromZero=${this._config.start_from_zero}
           ></modern-circular-gauge-element>
           ${typeof this._config.secondary != "string" ? 
-          this._config.secondary?.show_gauge == "outter" || this._config.secondary?.show_gauge == "inner" ?
+          this._config.secondary?.show_gauge && this._config.secondary?.show_gauge != "none" ?
           this._renderSecondaryGauge()
           : nothing
           : nothing}
           ${typeof this._config.tertiary != "string" ? 
-          this._config.tertiary?.show_gauge == "outter" || this._config.tertiary?.show_gauge == "inner" ?
+          this._config.tertiary?.show_gauge && this._config.tertiary?.show_gauge != "none" ?
           this._renderTertiaryRing()
           : nothing
           : nothing}

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -14,6 +14,7 @@ export interface BaseEntityConfig {
     min?: number | string;
     max?: number | string;
     needle?: boolean;
+    show_gauge?: "none" | "inner" | "outter" | "outer";
     show_state?: boolean;
     show_unit?: boolean;
     state_text?: string;
@@ -28,14 +29,12 @@ export interface BaseEntityConfig {
 
 export interface SecondaryEntity extends BaseEntityConfig {
     template?: string;
-    show_gauge?: "none" | "inner" | "outter";
     state_size?: "small" | "big";
     gauge_width?: number;
     [key: string]: any;
 };
 
 export interface TertiaryEntity extends BaseEntityConfig {
-    show_gauge?: "none" | "inner" | "outter";
     [key: string]: any;
 }
 


### PR DESCRIPTION
Fixes some spelling mistakes like "outter" instead of "outer" and "Cicular" instead of "Circular".

Some of these mistakes have been present from the beginning of this repo.