### PR TITLE
fix: incorrect icon size in stretched card

### DIFF
--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -16,7 +16,6 @@ import { actionHandler } from "../utils/action-handler-directive";
 import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS, MAX_ANGLE } from "../const";
 import { RenderTemplateResult, subscribeRenderTemplate } from "../ha/data/ws-templates";
 import { isTemplate } from "../utils/template";
-import { mdiHelp } from "@mdi/js";
 import "../components/modern-circular-gauge-element";
 import "../components/modern-circular-gauge-state";
 import "../components/modern-circular-gauge-icon";

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -19,6 +19,7 @@ import { isTemplate } from "../utils/template";
 import { mdiHelp } from "@mdi/js";
 import "../components/modern-circular-gauge-element";
 import "../components/modern-circular-gauge-state";
+import "../components/modern-circular-gauge-icon";
 
 const ROTATE_ANGLE = 360 - MAX_ANGLE / 2 - 90;
 const RADIUS = 47;
@@ -367,17 +368,11 @@ export class ModernCircularGauge extends LitElement {
     const secondaryHasLabel = typeof this._config?.secondary != "string" && this._config?.secondary?.label;
 
     return html`
-    <div class="icon-container">
-      <div class="icon-wrapper" style=${styleMap({ "--gauge-color": gaugeForegroundStyle?.color && gaugeForegroundStyle.color != "adaptive" ? gaugeForegroundStyle.color : computeSegments(value, segments, this._config?.smooth_segments, this) })}>
-        <ha-state-icon
-          class=${classMap({ "adaptive": !!this._config?.adaptive_icon_color, "big": !this._hasSecondary })}
-          style=${styleMap({ "bottom": this._config?.icon_vertical_position ? `${this._config.icon_vertical_position}%` : secondaryHasLabel && !iconCenter ? "15%" : undefined, "--gauge-icon-size": this._config?.icon_size ? `${this._config.icon_size}%` : undefined })}
-          .hass=${this.hass}
-          .stateObj=${stateObj}
-          .icon=${iconOverride}
-        ></ha-state-icon>
-      </div>
-    </div>
+    <modern-circular-gauge-icon
+      .hass=${this.hass}
+      .stateObj=${stateObj}
+      .icon=${iconOverride}
+    ></modern-circular-gauge-icon>
     `;
   }
 
@@ -1059,32 +1054,19 @@ export class ModernCircularGauge extends LitElement {
     }
 
     .icon-container {
-      display: flex;
       position: absolute;
       top: 0;
       left: 0;
       right: 0;
       bottom: 0;
-      justify-content: center;
-      align-items: center;
       z-index: 1;
     }
 
     .icon-wrapper {
-      position: relative;
       display: flex;
-      width: 100%;
-      height: auto;
-      max-height: 100%;
-      padding: 0;
-      margin: 0;
+      justify-content: center;
+      align-items: center;
       overflow: hidden;
-    }
-
-    .icon-wrapper:before {
-      display: block;
-      content: "";
-      padding-top: 100%;
     }
 
     .icon-center .icon-wrapper {
@@ -1094,13 +1076,21 @@ export class ModernCircularGauge extends LitElement {
 
     ha-state-icon, .warning-icon {
       position: absolute;
-      bottom: 21%;
-      left: 50%;
-      transform: translate(-50%, 50%);
-      --mdc-icon-size: auto;
+      /* bottom: 20%; */
+      /* left: 50%; */
+      /* transform: translate(-50%, 50%); */
+      --mdc-icon-size: 100%;
       color: var(--primary-color);
       --gauge-icon-size: 12%;
       --ha-icon-display: flex;
+    }
+
+    modern-circular-gauge-icon {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
     }
 
     .icon-center ha-state-icon, .icon-center ha-state-icon.big, .icon-center .warning-icon {
@@ -1110,13 +1100,15 @@ export class ModernCircularGauge extends LitElement {
     }
 
     ha-state-icon.big, .warning-icon {
-      bottom: 24%;
+      /* bottom: 23%; */
       --gauge-icon-size: 18%;
     }
 
     ha-state-icon, ha-svg-icon {
-      width: var(--gauge-icon-size);
-      height: var(--gauge-icon-size);
+      /* width: var(--gauge-icon-size); */
+      /* height: var(--gauge-icon-size); */
+      width: 100%;
+      height: 100%;
     }
 
     .warning-icon {

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -166,7 +166,7 @@ export class ModernCircularGauge extends LitElement {
       if (isTemplate(this._config.entity)) {
         return this._renderWarning();
       } else {
-        return this._renderWarning(this._config.entity, "", undefined, mdiHelp);
+        return this._renderWarning(this._config.entity, "", undefined, "mdi:help");
       }
     }
 
@@ -310,18 +310,13 @@ export class ModernCircularGauge extends LitElement {
           .hass=${this.hass}
           .stateOverride=${stateText}
         ></modern-circular-gauge-state>
-        <div class="icon-container">
-          <div class="icon-wrapper">
-            ${stateObj ? html`
-            <ha-state-icon
-              class="big warning-icon"
-              .hass=${this.hass}
-              .stateObj=${stateObj}
-              .icon=${icon}
-            ></ha-state-icon>
-            ` : html`<ha-svg-icon class="warning-icon" .path=${icon}></ha-svg-icon>`}
-          </div>
-        </div>
+        <modern-circular-gauge-icon
+          class="warning-icon"
+          .hass=${this.hass}
+          .stateObj=${stateObj}
+          .icon=${icon}
+          .position=${iconCenter ? 3 : 2}
+        ></modern-circular-gauge-icon>
       </div>
       </ha-card>
       `;
@@ -366,12 +361,18 @@ export class ModernCircularGauge extends LitElement {
     const value = Number(templatedState ?? stateObj.state);
     const iconCenter = !(this._config?.show_state ?? false) && (this._config?.show_icon ?? true);
     const secondaryHasLabel = typeof this._config?.secondary != "string" && this._config?.secondary?.label;
+    const iconPosition = secondaryHasLabel ? 0 : this._hasSecondary ? 1 : iconCenter ? 3 : 2;
 
     return html`
     <modern-circular-gauge-icon
+      class=${classMap({ "adaptive": !!this._config?.adaptive_icon_color })}
+      style=${styleMap({ "--gauge-color": gaugeForegroundStyle?.color && gaugeForegroundStyle.color != "adaptive" ? gaugeForegroundStyle.color : computeSegments(value, segments, this._config?.smooth_segments, this) })}
       .hass=${this.hass}
       .stateObj=${stateObj}
       .icon=${iconOverride}
+      .position=${iconPosition}
+      .iconVerticalPositionOverride=${this._config?.icon_vertical_position}
+      .iconSizeOverride=${this._config?.icon_size}
     ></modern-circular-gauge-icon>
     `;
   }
@@ -1053,62 +1054,13 @@ export class ModernCircularGauge extends LitElement {
       opacity: 1;
     }
 
-    .icon-container {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      z-index: 1;
-    }
-
-    .icon-wrapper {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      overflow: hidden;
-    }
-
-    .icon-center .icon-wrapper {
-      justify-content: center;
-      align-items: center;
-    }
-
-    ha-state-icon, .warning-icon {
-      position: absolute;
-      /* bottom: 20%; */
-      /* left: 50%; */
-      /* transform: translate(-50%, 50%); */
-      --mdc-icon-size: 100%;
-      color: var(--primary-color);
-      --gauge-icon-size: 12%;
-      --ha-icon-display: flex;
-    }
-
     modern-circular-gauge-icon {
       position: absolute;
       top: 0;
       bottom: 0;
       left: 0;
       right: 0;
-    }
-
-    .icon-center ha-state-icon, .icon-center ha-state-icon.big, .icon-center .warning-icon {
-      position: static;
-      transform: unset;
-      --gauge-icon-size: 30%;
-    }
-
-    ha-state-icon.big, .warning-icon {
-      /* bottom: 23%; */
-      --gauge-icon-size: 18%;
-    }
-
-    ha-state-icon, ha-svg-icon {
-      /* width: var(--gauge-icon-size); */
-      /* height: var(--gauge-icon-size); */
-      width: 100%;
-      height: 100%;
+      color: var(--primary-color);
     }
 
     .warning-icon {
@@ -1121,11 +1073,6 @@ export class ModernCircularGauge extends LitElement {
 
     .value.adaptive, .secondary.adaptive, .tertiary-state.adaptive {
       fill: var(--gauge-color);
-    }
-
-    ha-icon {
-      display: flex;
-      justify-content: center;
     }
 
     .name {

--- a/src/components/modern-circular-gauge-icon.ts
+++ b/src/components/modern-circular-gauge-icon.ts
@@ -1,0 +1,101 @@
+import { html, LitElement, css, PropertyValues, svg, nothing } from "lit";
+import { customElement, property, queryAsync, state } from "lit/decorators.js";
+import { HomeAssistant } from "../ha/types";
+import { HassEntity } from "home-assistant-js-websocket";
+
+@customElement("modern-circular-gauge-icon")
+export class ModernCircularGaugeIcon extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @property() public icon?: string;
+
+  @queryAsync('ha-state-icon') private _haStateIcon!: Promise<HTMLElement>;
+
+  @state() private _updated = false;
+
+  protected firstUpdated(_changedProperties: PropertyValues): void {
+    super.firstUpdated(_changedProperties);
+  }
+
+  protected updated(_changedProperties: PropertyValues): void {
+    super.updated(_changedProperties);
+    if (this._updated) {
+      return;
+    }
+
+    this._haStateIcon.then( async (haStateIcon) => {
+      if (!haStateIcon.shadowRoot) {
+        return;
+      }
+
+      this._getSvgFromHaStateIcon(haStateIcon);
+      
+      if (!this._updated) {
+        const observer = new MutationObserver(() => {
+          this._getSvgFromHaStateIcon(haStateIcon);
+          observer.disconnect();
+        });
+
+        observer.observe(haStateIcon.shadowRoot, {
+          childList: true,
+          subtree: true,
+        });
+      }
+    });
+  }
+
+  private _getSvgFromHaStateIcon(haStateIconEl) {
+    const haIcon = haStateIconEl.shadowRoot?.querySelector('ha-icon');
+    if (!haIcon) {
+      return;
+    }
+    (haIcon as any)?.updateComplete?.then(() => {
+      const haSvgIcon = haIcon?.shadowRoot?.querySelector('ha-svg-icon');
+      const svg = haSvgIcon?.shadowRoot?.querySelector('svg');
+      if (svg) {
+        const gaugeIcon = this.shadowRoot!.querySelector('.gauge-icon') as SVGElement;
+        const iconGroup = svg.querySelector('g');
+        if (gaugeIcon && iconGroup) {
+          gaugeIcon.appendChild(iconGroup);
+          this._updated = true;
+        }
+      }
+    });
+  }
+
+  protected render() {
+    return html`
+    <ha-state-icon
+      .hass=${this.hass}
+      .stateObj=${this.stateObj}
+      .icon=${this.icon}
+    ></ha-state-icon>
+    <svg class="gauge-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    </svg>`;
+  }
+
+  static styles = css`
+    :host {
+      width: 100%;
+      height: 100%;
+    }
+
+    svg {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    g {
+      transform-origin: center;
+      transform: scale(0.18);
+    }
+
+    ha-state-icon {
+      visibility: hidden;
+      position: absolute;
+    }
+  `;
+}

--- a/src/components/modern-circular-gauge-icon.ts
+++ b/src/components/modern-circular-gauge-icon.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, css, PropertyValues, svg, nothing } from "lit";
+import { html, LitElement, css, PropertyValues } from "lit";
 import { customElement, property, queryAsync, state } from "lit/decorators.js";
 import { HomeAssistant } from "../ha/types";
 import { HassEntity } from "home-assistant-js-websocket";

--- a/src/components/modern-circular-gauge-icon.ts
+++ b/src/components/modern-circular-gauge-icon.ts
@@ -3,6 +3,10 @@ import { customElement, property, queryAsync, state } from "lit/decorators.js";
 import { HomeAssistant } from "../ha/types";
 import { HassEntity } from "home-assistant-js-websocket";
 
+
+const ICONPOSITIONS = [-3.6, -4.8, -5.52, -12];
+const ICONSIZES = [0.12, 0.12, 0.18, 0.3];
+
 @customElement("modern-circular-gauge-icon")
 export class ModernCircularGaugeIcon extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
@@ -10,6 +14,16 @@ export class ModernCircularGaugeIcon extends LitElement {
   @property({ attribute: false }) public stateObj?: HassEntity;
 
   @property() public icon?: string;
+
+  /**
+   * Position of the icon in the gauge.
+   * 0: Secondary with label, 1: Secondary, 2: No secondary, 3: No primary state
+   */
+  @property({ type: Number }) public position = 2;
+
+  @property({ type: Number }) public iconVerticalPositionOverride?: number;
+
+  @property({ type: Number }) public iconSizeOverride?: number;
 
   @queryAsync('ha-state-icon') private _haStateIcon!: Promise<HTMLElement>;
 
@@ -55,7 +69,7 @@ export class ModernCircularGaugeIcon extends LitElement {
       const haSvgIcon = haIcon?.shadowRoot?.querySelector('ha-svg-icon');
       const svg = haSvgIcon?.shadowRoot?.querySelector('svg');
       if (svg) {
-        const gaugeIcon = this.shadowRoot!.querySelector('.gauge-icon') as SVGElement;
+        const gaugeIcon = this.shadowRoot!.querySelector('.gauge-icon-group') as SVGElement;
         const iconGroup = svg.querySelector('g');
         if (gaugeIcon && iconGroup) {
           gaugeIcon.appendChild(iconGroup);
@@ -63,6 +77,20 @@ export class ModernCircularGaugeIcon extends LitElement {
         }
       }
     });
+  }
+
+  private _computeIconPosition(): number {
+    if (this.iconVerticalPositionOverride !== undefined) {
+      return this.iconVerticalPositionOverride * 24 * -0.01;
+    }
+    return ICONPOSITIONS[this.position];
+  }
+
+  private _computeIconSize(): number {
+    if (this.iconSizeOverride !== undefined) {
+      return this.iconSizeOverride * 0.01;
+    }
+    return ICONSIZES[this.position];
   }
 
   protected render() {
@@ -73,6 +101,8 @@ export class ModernCircularGaugeIcon extends LitElement {
       .icon=${this.icon}
     ></ha-state-icon>
     <svg class="gauge-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <g class="gauge-icon-group" transform="translate(0 12) translate(0 ${this._computeIconPosition()}) translate(12 12) scale(${this._computeIconSize()}) translate(-12 -12)">
+      </g>
     </svg>`;
   }
 
@@ -80,6 +110,7 @@ export class ModernCircularGaugeIcon extends LitElement {
     :host {
       width: 100%;
       height: 100%;
+      fill: var(--icon-primary-color, currentcolor);
     }
 
     svg {
@@ -88,9 +119,12 @@ export class ModernCircularGaugeIcon extends LitElement {
       display: block;
     }
 
-    g {
-      transform-origin: center;
-      transform: scale(0.18);
+    path.primary-path {
+      opacity: var(--icon-primary-opactity, 1);
+    }
+    path.secondary-path {
+      fill: var(--icon-secondary-color, currentcolor);
+      opacity: var(--icon-secondary-opactity, 0.5);
     }
 
     ha-state-icon {


### PR DESCRIPTION
Aims to fix incorrect icon size in horizontally stretched card just like in [#102](https://github.com/selvalt7/modern-circular-gauge/pull/102) but now with better browser compatibility.

I had to think of a method to extract svg data from ha-state-icon to append it into my svg element.