### PR TITLE
feat: template support in visual editor

### DIFF
--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -11,44 +11,52 @@ import "../components/ha-form-mcg-list";
 const FORM = [
   {
     name: "entity",
+    type: "mcg-template",
     required: true,
-    selector: { entity: {
-        domain: NUMBER_ENTITY_DOMAINS,
+    schema: { entity: {
+      domain: NUMBER_ENTITY_DOMAINS,
     }},
+  },
+  {
+    name: "name",
+    type: "mcg-template",
+    schema: { text: {} },
   },
   {
     name: "",
     type: "grid",
     schema: [
       {
-        name: "name",
-        selector: { text: {} },
+        name: "icon",
+        type: "mcg-template",
+        flatten: true,
+        schema: { icon: {} },
+        context: {
+          icon_entity: "entity",
+        },
       },
       {
         name: "unit",
         selector: { text: {} },
       },
       {
-        name: "icon",
-        selector: { icon: {} },
-        context: { icon_entity: "entity" },
+        name: "min",
+        type: "mcg-template",
+        default: DEFAULT_MIN,
+        label: "generic.minimum",
+        schema: { number: { step: 0.1 } },
+      },
+      {
+        name: "max",
+        type: "mcg-template",
+        default: DEFAULT_MAX,
+        label: "generic.maximum",
+        schema: { number: { step: 0.1 } },
       },
       {
         name: "needle",
         label: "gauge.needle_gauge",
         selector: { boolean: {} },
-      },
-      {
-        name: "min",
-        default: DEFAULT_MIN,
-        label: "generic.minimum",
-        selector: { number: { step: 0.1 } },
-      },
-      {
-        name: "max",
-        default: DEFAULT_MAX,
-        label: "generic.maximum",
-        selector: { number: { step: 0.1 } },
       },
       {
         name: "show_name",
@@ -94,15 +102,17 @@ const FORM = [
         schema: [
           {
             name: "from",
+            type: "mcg-template",
             label: "From",
             required: true,
-            selector: { number: { step: 0.1 } },
+            schema: { number: { step: 0.1 } },
           },
           {
             name: "color",
+            type: "mcg-template",
             label: "heading.entity_config.color",
             required: true,
-            selector: { color_rgb: {} },
+            schema: { color_rgb: {} },
           },
         ],
       },

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -55,6 +55,7 @@ export class ModernCircularGaugeEditor extends LitElement {
           {
             name: "icon",
             type: "mcg-template",
+            flatten: true,
             schema: { icon: {} },
             context: {
               icon_entity: "entity",

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -70,14 +70,12 @@ export class ModernCircularGaugeEditor extends LitElement {
             name: "min",
             type: "mcg-template",
             default: DEFAULT_MIN,
-            label: "generic.minimum",
             schema: { number: { step: 0.1 } },
           },
           {
             name: "max",
             type: "mcg-template",
             default: DEFAULT_MAX,
-            label: "generic.maximum",
             schema: { number: { step: 0.1 } },
           },
         ],
@@ -86,7 +84,6 @@ export class ModernCircularGaugeEditor extends LitElement {
         getTertiarySchema(showTertiaryGaugeOptions),
       {
         name: "header_position",
-        label: "Header position",
         selector: {
           select: {
             options: [
@@ -103,47 +100,39 @@ export class ModernCircularGaugeEditor extends LitElement {
         schema: [
           {
             name: "needle",
-            label: "gauge.needle_gauge",
             selector: { boolean: {} },
           },
           {
             name: "smooth_segments",
-            label: "Smooth color segments",
             selector: { boolean: {} },
           },
           {
             name: "show_header",
-            label: "Show header",
             default: true,
             selector: { boolean: {} },
           },
           {
             name: "show_state",
-            label: "Show state",
             default: true,
             selector: { boolean: {} },
           },
           {
             name: "show_unit",
-            label: "Show unit",
             default: true,
             selector: { boolean: {} },
           },
           {
             name: "show_icon",
-            label: "Show icon",
             default: true,
             selector: { boolean: {} },
           },
           {
             name: "adaptive_icon_color",
-            label: "Adaptive icon color",
             default: false,
             selector: { boolean: {} },
           },
           {
             name: "icon_entity",
-            label: "Icon entity",
             default: "primary",
             selector: {
               select: {
@@ -159,7 +148,6 @@ export class ModernCircularGaugeEditor extends LitElement {
           },
           {
             name: "adaptive_state_color",
-            label: "Adaptive state color",
             default: false,
             selector: { boolean: {} },
           },
@@ -178,14 +166,12 @@ export class ModernCircularGaugeEditor extends LitElement {
               {
                 name: "from",
                 type: "mcg-template",
-                label: "From",
                 required: true,
                 schema: { number: { step: 0.1 } },
               },
               {
                 name: "color",
                 type: "mcg-template",
-                label: "heading.entity_config.color",
                 required: true,
                 schema: { color_rgb: {} },
               },
@@ -194,7 +180,6 @@ export class ModernCircularGaugeEditor extends LitElement {
           {
             name: "label",
             type: "mcg-template",
-            label: "Label",
             schema: { text: {} },
           },
         ]

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -8,6 +8,7 @@ import { getSecondarySchema, getTertiarySchema } from "./mcg-schema";
 import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS } from "../const";
 import memoizeOne from "memoize-one";
 import "../components/ha-form-mcg-list";
+import "../components/ha-form-mcg-template";
 
 @customElement("modern-circular-gauge-editor")
 export class ModernCircularGaugeEditor extends LitElement {
@@ -36,14 +37,16 @@ export class ModernCircularGaugeEditor extends LitElement {
     [
       {
         name: "entity",
+        type: "mcg-template",
         required: true,
-        selector: { entity: {
+        schema: { entity: {
           domain: NUMBER_ENTITY_DOMAINS,
         }},
       },
       {
         name: "name",
-        selector: { text: {} },
+        type: "mcg-template",
+        schema: { text: {} },
       },
       {
         name: "",
@@ -51,7 +54,8 @@ export class ModernCircularGaugeEditor extends LitElement {
         schema: [
           {
             name: "icon",
-            selector: { icon: {} },
+            type: "mcg-template",
+            schema: { icon: {} },
             context: {
               icon_entity: "entity",
             },
@@ -62,15 +66,17 @@ export class ModernCircularGaugeEditor extends LitElement {
           },
           {
             name: "min",
+            type: "mcg-template",
             default: DEFAULT_MIN,
             label: "generic.minimum",
-            selector: { number: { step: 0.1 } },
+            schema: { number: { step: 0.1 } },
           },
           {
             name: "max",
+            type: "mcg-template",
             default: DEFAULT_MAX,
             label: "generic.maximum",
-            selector: { number: { step: 0.1 } },
+            schema: { number: { step: 0.1 } },
           },
         ],
       },
@@ -168,23 +174,26 @@ export class ModernCircularGaugeEditor extends LitElement {
             schema: [
               {
                 name: "from",
+                type: "mcg-template",
                 label: "From",
                 required: true,
-                selector: { number: { step: 0.1 } },
+                schema: { number: { step: 0.1 } },
               },
               {
                 name: "color",
+                type: "mcg-template",
                 label: "heading.entity_config.color",
                 required: true,
-                selector: { color_rgb: {} },
+                schema: { color_rgb: {} },
               },
             ],
           },
           {
-              name: "label",
-              label: "Label",
-              selector: { text: {} },
-          }
+            name: "label",
+            type: "mcg-template",
+            label: "Label",
+            schema: { text: {} },
+          },
         ]
       },
       {

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -22,15 +22,17 @@ export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
       schema: [
         {
           name: "min",
+          type: "mcg-template",
           default: DEFAULT_MIN,
           label: "generic.minimum",
-          selector: { number: { step: 0.1 } },
+          schema: { number: { step: 0.1 } },
         },
         {
           name: "max",
+          type: "mcg-template",
           default: DEFAULT_MAX,
           label: "generic.maximum",
-          selector: { number: { step: 0.1 } },
+          schema: { number: { step: 0.1 } },
         },
         {
           name: "needle",
@@ -52,15 +54,17 @@ export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
           schema: [
             {
               name: "from",
+              type: "mcg-template",
               label: "From",
               required: true,
-              selector: { number: { step: 0.1 } },
+              schema: { number: { step: 0.1 } },
             },
             {
               name: "color",
+              type: "mcg-template",
               label: "heading.entity_config.color",
               required: true,
-              selector: { color_rgb: {} },
+              schema: { color_rgb: {} },
             },
           ],
         },
@@ -78,7 +82,8 @@ export function getSecondarySchema(showGaugeOptions: boolean) {
     schema: [
       {
         name: "entity",
-        selector: { entity: { 
+        type: "mcg-template",
+        schema: { entity: {
           domain: NUMBER_ENTITY_DOMAINS,
         }},
       },
@@ -139,7 +144,8 @@ export function getTertiarySchema(showGaugeOptions: boolean) {
     schema: [
       {
         name: "entity",
-        selector: { entity: { 
+        type: "mcg-template",
+        schema: { entity: {
           domain: NUMBER_ENTITY_DOMAINS,
         }},
       },

--- a/src/components/ha-form-mcg-template.ts
+++ b/src/components/ha-form-mcg-template.ts
@@ -6,6 +6,7 @@ import { HaFormBaseSchema, HaFormDataContainer } from "../ha/components/ha-form-
 import { fireEvent } from "../ha/common/dom/fire_event";
 import { isTemplate } from "../utils/template";
 import { mdiCodeBraces, mdiListBoxOutline } from "@mdi/js";
+import localize from "../localize/localize";
 
 @customElement("ha-form-mcg-template")
 export class HaFormMCGTemplate extends LitElement {
@@ -73,7 +74,7 @@ export class HaFormMCGTemplate extends LitElement {
         >
         </ha-form>
         <ha-button .disabled=${this.disabled} @click=${this._toggleTemplateMode}>
-          ${this._templateMode ? "Switch to Form" : "Switch to Template"}
+          ${this._templateMode ? localize(this.hass, "editor.switch_to_form") : localize(this.hass, "editor.switch_to_template")}
           <ha-svg-icon slot="icon" .path=${this._templateMode ? mdiListBoxOutline : mdiCodeBraces}></ha-svg-icon>
         </ha-button>
       </div>

--- a/src/components/ha-form-mcg-template.ts
+++ b/src/components/ha-form-mcg-template.ts
@@ -1,0 +1,107 @@
+import { html, LitElement, css } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { HomeAssistant } from "../ha/types";
+import { HaFormMCGTemplateSchema } from "./type";
+import { HaFormBaseSchema, HaFormDataContainer } from "../ha/components/ha-form-types";
+import { fireEvent } from "../ha/common/dom/fire_event";
+import { isTemplate } from "../utils/template";
+import { mdiCodeBraces, mdiListBoxOutline } from "@mdi/js";
+
+@customElement("ha-form-mcg-template")
+export class HaFormMCGTemplate extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public data!: HaFormDataContainer;
+
+  @property({ attribute: false }) public schema!: HaFormMCGTemplateSchema;
+
+  @property({ type: String }) public template = "";
+
+  @property({ attribute: false }) public computeLabel?: (
+    schema: HaFormBaseSchema,
+    data?: HaFormDataContainer
+  ) => string;
+
+  @state() private _templateMode: boolean = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._templateMode = isTemplate(this.data as unknown as string);
+  }
+
+  private _computeSelector(): any[] {
+    return [
+      {
+        name: this.schema.name,
+        label: this.schema.label,
+        selector: this.schema.schema,
+      }
+    ];
+  }
+
+  protected render() {
+    const DATA = { [this.schema.name]: this.data };
+
+    const dataIsTemplate = this._templateMode ?? isTemplate((DATA[this.schema.name] as unknown) as string);
+    
+    let schema = Array.isArray(this.schema.schema) ? this.schema.schema : this._computeSelector();
+    
+    if (dataIsTemplate) {
+      schema = [
+        {
+          name: this.schema.name,
+          label: this.schema.label,
+          selector: { template: {} },
+        }
+      ]
+    }
+
+    return html`
+      <div class="selector-container">
+        <ha-form
+          .hass=${this.hass}
+          .data=${DATA}
+          .schema=${schema}
+          .computeLabel=${this.computeLabel}
+          @value-changed=${this._valueChanged}
+        >
+        </ha-form>
+        <ha-icon-button
+          .path=${this._templateMode ? mdiListBoxOutline : mdiCodeBraces}
+          @click=${this._toggleTemplateMode}
+        ></ha-icon-button>
+      </div>
+    `;
+  }
+
+  private _toggleTemplateMode(): void {
+    this._templateMode = !this._templateMode;
+    if (this._templateMode) {
+      const value = this.data != undefined ? String(this.data) : "";
+      fireEvent(this, "value-changed", { value: value });
+    }
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const value = ev.detail.value[this.schema.name];
+    if (value === undefined) {
+      return;
+    }
+    fireEvent(this, "value-changed", { value: value });
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    .selector-container {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    ha-form {
+      flex: 1;
+    }
+  `;
+}

--- a/src/components/ha-form-mcg-template.ts
+++ b/src/components/ha-form-mcg-template.ts
@@ -37,6 +37,7 @@ export class HaFormMCGTemplate extends LitElement {
         name: this.schema.name,
         label: this.schema.label,
         selector: this.schema.schema,
+        required: this.schema.required,
         context: this.schema.context || undefined,
       }
     ];
@@ -54,6 +55,7 @@ export class HaFormMCGTemplate extends LitElement {
         {
           name: this.schema.name,
           label: this.schema.label,
+          required: this.schema.required,
           selector: { template: {} },
         }
       ]

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -13,5 +13,6 @@ export interface HaFormMCGListSchema extends HaFormBaseSchema {
 export interface HaFormMCGTemplateSchema extends HaFormBaseSchema {
   type: "mcg-template";
   label?: string;
+  flatten?: boolean;
   schema?: readonly any[] | any;
 }

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -9,3 +9,9 @@ export interface HaFormMCGListSchema extends HaFormBaseSchema {
   expanded?: boolean;
   schema: readonly any[];
 }
+
+export interface HaFormMCGTemplateSchema extends HaFormBaseSchema {
+  type: "mcg-template";
+  label?: string;
+  schema?: readonly any[] | any;
+}

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -18,6 +18,8 @@
     "from": "From",
     "color": "Color",
     "label": "Label",
+    "switch_to_form": "Switch To Form",
+    "switch_to_template": "Switch To Template",
     "header_position_options": {
       "options": {
         "top": "Top",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -18,6 +18,8 @@
     "from": "Od",
     "color": "Kolor",
     "label": "Etykieta",
+    "switch_to_form": "Przełącz na Selektor",
+    "switch_to_template": "Przełącz na Template",
     "header_position_options": {
       "options": {
         "top": "Na górze",


### PR DESCRIPTION
Adds template editor to every template supported config.
Template editor can be toggled with a button under the selector, if config entry is already a template, it will switch to a template editor automatically.
<img width="1037" height="910" alt="editor" src="https://github.com/user-attachments/assets/192861f7-43ce-4200-84c5-08b0eff01f56" />
