### PR TITLE
feat: editor translation support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@babel/preset-env": "^7.26.9",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^28.0.3",
+        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.3.1",
         "@rollup/plugin-typescript": "^12.1.2",
         "@semantic-release/changelog": "^6.0.3",
@@ -1960,6 +1961,27 @@
       },
       "peerDependencies": {
         "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/preset-env": "^7.26.9",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
+    "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@semantic-release/changelog": "^6.0.3",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,6 +2,7 @@ import babel from "@rollup/plugin-babel";
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
+import json from "@rollup/plugin-json";
 
 export default [
   {
@@ -18,6 +19,7 @@ export default [
         declaration: false,
       }),
       nodeResolve(),
+      json(),
       commonjs(),
       babel({
         exclude: "node_modules/**",

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -7,6 +7,7 @@ import { fireEvent } from "../ha/common/dom/fire_event";
 import { mdiSegment } from "@mdi/js";
 import { hexToRgb } from "../utils/color";
 import "../components/ha-form-mcg-list";
+import localize from "../localize/localize";
 
 const FORM = [
   {
@@ -35,48 +36,40 @@ const FORM = [
       },
       {
         name: "needle",
-        label: "gauge.needle_gauge",
         selector: { boolean: {} },
       },
       {
         name: "min",
         default: DEFAULT_MIN,
-        label: "generic.minimum",
         selector: { number: { step: 0.1 } },
       },
       {
         name: "max",
         default: DEFAULT_MAX,
-        label: "generic.maximum",
         selector: { number: { step: 0.1 } },
       },
       {
         name: "show_name",
-        label: "Show name",
         default: false,
         selector: { boolean: {} },
       },
       {
         name: "show_state",
-        label: "Show state",
         default: true,
         selector: { boolean: {} },
       },
       {
         name: "show_unit",
-        label: "Show unit",
         default: true,
         selector: { boolean: {} },
       },
       {
         name: "show_icon",
-        label: "Show icon",
         default: true,
         selector: { boolean: {} },
       },
       {
         name: "smooth_segments",
-        label: "Smooth color segments",
         selector: { boolean: {} },
       },
     ]
@@ -84,7 +77,6 @@ const FORM = [
   {
     name: "segments",
     type: "mcg-list",
-    title: "Color segments",
     iconPath: mdiSegment,
     schema: [
       {
@@ -154,11 +146,7 @@ export class ModernCircularGaugeBadgeEditor extends LitElement {
   }
 
   private _computeLabel = (schema: any) => {
-    let label = this.hass?.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
-    if (label) return label;
-    label = this.hass?.localize(`ui.panel.lovelace.editor.card.${schema.label}`);
-    if (label) return label;
-    return schema.label;
+    return this.hass?.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`) || localize(this.hass, `editor.${schema.name}`);
   };
 
   private _valueChanged(ev: CustomEvent): void {

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -86,13 +86,11 @@ const FORM = [
         schema: [
           {
             name: "from",
-            label: "From",
             required: true,
             selector: { number: { step: 0.1 } },
           },
           {
             name: "color",
-            label: "heading.entity_config.color",
             required: true,
             selector: { color_rgb: {} },
           },

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -8,6 +8,7 @@ import { getSecondarySchema, getTertiarySchema } from "./mcg-schema";
 import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS } from "../const";
 import memoizeOne from "memoize-one";
 import "../components/ha-form-mcg-list";
+import localize from "../localize/localize";
 
 @customElement("modern-circular-gauge-editor")
 export class ModernCircularGaugeEditor extends LitElement {
@@ -85,6 +86,7 @@ export class ModernCircularGaugeEditor extends LitElement {
               { label: "Top", value: "top" },
               { label: "Bottom", value: "bottom" },
             ],
+            translation_key: "header_position_options",
           },
         },
       },
@@ -144,6 +146,7 @@ export class ModernCircularGaugeEditor extends LitElement {
                   { value: "tertiary", label: "Tertiary" },
                 ],
                 mode: "dropdown",
+                translation_key: "icon_entity_options",
               },
             },
           },
@@ -158,7 +161,6 @@ export class ModernCircularGaugeEditor extends LitElement {
       {
         name: "segments",
         type: "mcg-list",
-        title: "Color segments",
         iconPath: mdiSegment,
         schema: [
           {
@@ -214,17 +216,18 @@ export class ModernCircularGaugeEditor extends LitElement {
         .data=${DATA}
         .schema=${schema}
         .computeLabel=${this._computeLabel}
+        .localizeValue=${this._localizeValue}
         @value-changed=${this._valueChanged}
     ></ha-form>
     `;
   }
 
+  private _localizeValue = (key: string) => {
+    return localize(this.hass, `editor.${key}`);
+  };
+
   private _computeLabel = (schema: any) => {
-    let label = this.hass?.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
-    if (label) return label;
-    label = this.hass?.localize(`ui.panel.lovelace.editor.card.${schema.label}`);
-    if (label) return label;
-    return schema.label;
+    return this.hass?.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`) || localize(this.hass, `editor.${schema.name}`);
   };
 
   private _valueChanged(ev: CustomEvent): void {

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -13,6 +13,7 @@ export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
           { value: "outer", label: "Outer gauge" },
         ],
         mode: "dropdown",
+        translation_key: "show_gauge_options",
       }},
     },
     {
@@ -99,6 +100,7 @@ export function getSecondarySchema(showGaugeOptions: boolean) {
                 { value: "big", label: "Big"},
               ],
               mode: "dropdown",
+              translation_key: "state_size_options",
             }},
           },
           {

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -5,7 +5,6 @@ export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
   return [
     {
       name: "show_gauge",
-      label: "Gauge visibility",
       selector: { select: {
         options: [
           { value: "none", label: "None" },
@@ -24,18 +23,15 @@ export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
         {
           name: "min",
           default: DEFAULT_MIN,
-          label: "generic.minimum",
           selector: { number: { step: 0.1 } },
         },
         {
           name: "max",
           default: DEFAULT_MAX,
-          label: "generic.maximum",
           selector: { number: { step: 0.1 } },
         },
         {
           name: "needle",
-          label: "gauge.needle_gauge",
           selector: { boolean: {} },
         },
       ],
@@ -43,7 +39,6 @@ export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
     {
       name: "segments",
       type: "mcg-list",
-      title: "Color segments",
       iconPath: mdiSegment,
       schema: [
         {
@@ -53,13 +48,11 @@ export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
           schema: [
             {
               name: "from",
-              label: "From",
               required: true,
               selector: { number: { step: 0.1 } },
             },
             {
               name: "color",
-              label: "heading.entity_config.color",
               required: true,
               selector: { color_rgb: {} },
             },
@@ -93,7 +86,6 @@ export function getSecondarySchema(showGaugeOptions: boolean) {
           },
           {
             name: "state_size",
-            label: "State size",
             selector: { select: {
               options: [
                 { value: "small", label: "Small"},
@@ -105,19 +97,16 @@ export function getSecondarySchema(showGaugeOptions: boolean) {
           },
           {
             name: "show_state",
-            label: "Show state",
             default: true,
             selector: { boolean: {} },
           },
           {
             name: "show_unit",
-            label: "Show unit",
             default: true,
             selector: { boolean: {} },
           },
           {
             name: "adaptive_state_color",
-            label: "Adaptive state color",
             default: false,
             selector: { boolean: {} },
           },
@@ -136,7 +125,6 @@ export function getTertiarySchema(showGaugeOptions: boolean) {
   return {
     name: "tertiary",
     type: "expandable",
-    label: "Tertiary info",
     iconPath: mdiNumeric3BoxOutline,
     schema: [
       {
@@ -155,19 +143,16 @@ export function getTertiarySchema(showGaugeOptions: boolean) {
         schema: [
           {
             name: "show_state",
-            label: "Show state",
             default: true,
             selector: { boolean: {} },
           },
           {
             name: "show_unit",
-            label: "Show unit",
             default: true,
             selector: { boolean: {} },
           },
           {
             name: "adaptive_state_color",
-            label: "Adaptive state color",
             default: false,
             selector: { boolean: {} },
           },

--- a/src/components/ha-form-mcg-list.ts
+++ b/src/components/ha-form-mcg-list.ts
@@ -5,6 +5,7 @@ import { HaFormMCGListSchema } from "./type";
 import { HaFormBaseSchema, HaFormDataContainer } from "../ha/components/ha-form-types";
 import { mdiClose, mdiPlus } from "@mdi/js";
 import { fireEvent } from "../ha/common/dom/fire_event";
+import localize from "../localize/localize";
 
 @customElement("ha-form-mcg-list")
 export class MCG_List extends LitElement {
@@ -43,7 +44,7 @@ export class MCG_List extends LitElement {
         role="heading"
       >
         <ha-svg-icon .path=${this.schema.iconPath}></ha-svg-icon>
-        ${this.schema.title}
+        ${localize(this.hass, `editor.${this.schema.name}`)}
       </div>
       <div class="content">
         ${this.data ? this.data.map((row, index) => html`

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -6,7 +6,7 @@
     "secondary": "Secondary info",
     "tertiary": "Tertiary info",
     "state_size": "State size",
-    "show_gauge": "Show gauge",
+    "show_gauge": "Gauge visibility",
     "header_position": "Header position",
     "show_header": "Show header",
     "adaptive_icon_color": "Adaptive icon color",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -1,0 +1,48 @@
+{
+  "editor": {
+    "min": "Minimum",
+    "max": "Maximum",
+    "needle": "Display as needle gauge",
+    "secondary": "Secondary info",
+    "tertiary": "Tertiary info",
+    "state_size": "State size",
+    "show_gauge": "Show gauge",
+    "header_position": "Header position",
+    "show_header": "Show header",
+    "adaptive_icon_color": "Adaptive icon color",
+    "icon_entity": "Icon entity",
+    "adaptive_state_color": "Adaptive state color",
+    "show_unit": "Show unit",
+    "smooth_segments": "Smooth segments",
+    "segments": "Color segments",
+    "from": "From",
+    "color": "Color",
+    "label": "Label",
+    "header_position_options": {
+      "options": {
+        "top": "Top",
+        "bottom": "Bottom"
+      }
+    },
+    "icon_entity_options": {
+      "options": {
+        "primary": "Primary",
+        "secondary": "Secondary",
+        "tertiary": "Tertiary"
+      }
+    },
+    "show_gauge_options": {
+      "options": {
+        "none": "None",
+        "inner": "Inner gauge",
+        "outer": "Outer gauge"
+      }
+    },
+    "state_size_options": {
+      "options": {
+        "small": "Small",
+        "big": "Big"
+      }
+    }
+  }
+}

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -1,0 +1,48 @@
+{
+  "editor": {
+    "min": "Minimum",
+    "max": "Maksimum",
+    "needle": "Wyświetl jako wskaźnik igłowy",
+    "secondary": "Informacja drugorzędna",
+    "tertiary": "Informacja trzeciorzędna",
+    "state_size": "Rozmiar stanu",
+    "show_gauge": "Pokaż wskaźnik",
+    "header_position": "Pozycja nagłówka",
+    "show_header": "Pokaż nagłówek",
+    "adaptive_icon_color": "Adaptywny kolor ikony",
+    "icon_entity": "Encja ikony",
+    "adaptive_state_color": "Adaptywny kolor stanu",
+    "show_unit": "Pokaż jednostkę",
+    "smooth_segments": "Wygładzone segmenty",
+    "segments": "Segmenty kolorów",
+    "from": "Od",
+    "color": "Kolor",
+    "label": "Etykieta",
+    "header_position_options": {
+      "options": {
+        "top": "Na górze",
+        "bottom": "Na dole"
+      }
+    },
+    "icon_entity_options": {
+      "options": {
+        "primary": "Pierwszorzędna",
+        "secondary": "Drugorzędna",
+        "tertiary": "Trzeciorzędna"
+      }
+    },
+    "show_gauge_options": {
+      "options": {
+        "none": "Brak",
+        "inner": "Wewnętrzny wskaźnik",
+        "outer": "Zewnętrzny wskaźnik"
+      }
+    },
+    "state_size_options": {
+      "options": {
+        "small": "Mały",
+        "big": "Duży"
+      }
+    }
+  }
+}

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -6,7 +6,7 @@
     "secondary": "Informacja drugorzędna",
     "tertiary": "Informacja trzeciorzędna",
     "state_size": "Rozmiar stanu",
-    "show_gauge": "Pokaż wskaźnik",
+    "show_gauge": "Widoczność wskaźnika",
     "header_position": "Pozycja nagłówka",
     "show_header": "Pokaż nagłówek",
     "adaptive_icon_color": "Adaptywny kolor ikony",

--- a/src/localize/localize.ts
+++ b/src/localize/localize.ts
@@ -1,0 +1,30 @@
+import { HomeAssistant } from '../ha/types';
+import * as en from './languages/en.json';
+import * as pl from './languages/pl.json';
+
+const languages: Record<string, unknown> = {
+  en,
+  pl
+}
+
+const DEFAULT_LANG = "en";
+
+function getTranslatedString(key: string, lang: string = DEFAULT_LANG): string | undefined {
+  try {
+    return key.split('.').reduce((o, i) => (o as Record<string, unknown>)[i],
+      languages[lang]
+    ) as string;
+  } catch (_) {
+    return undefined;
+  }
+}
+
+export default function localize(hass: HomeAssistant, key: string): string {
+  const lang = hass.locale.language || DEFAULT_LANG;
+
+  let translatedString = getTranslatedString(key, lang);
+  if (!translatedString) {
+    translatedString = getTranslatedString(key, DEFAULT_LANG);
+  }
+  return translatedString ?? key;
+}


### PR DESCRIPTION
Adds localization support for visual editor, this pr includes only English and Polish language support but can be expanded by adding respected json files with translations and including it in the localize.ts.