### PR TITLE
feat: expanded and enhanced visual editor

### DIFF
--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -4,7 +4,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { ModernCircularGaugeBadgeConfig } from "./gauge-badge-config";
 import { NUMBER_ENTITY_DOMAINS, DEFAULT_MAX, DEFAULT_MIN } from "../const";
 import { fireEvent } from "../ha/common/dom/fire_event";
-import { mdiPalette, mdiSegment } from "@mdi/js";
+import { mdiFlipToBack, mdiFlipToFront, mdiPalette, mdiSegment } from "@mdi/js";
 import { hexToRgb } from "../utils/color";
 import "../components/ha-form-mcg-list";
 import { getGaugeStyleSchema } from "../card/mcg-schema";
@@ -108,11 +108,13 @@ const FORM = [
       {
         name: "gauge_foreground_style",
         type: "expandable",
+        iconPath: mdiFlipToFront,
         schema: getGaugeStyleSchema(14)
       },
       {
         name: "gauge_background_style",
         type: "expandable",
+        iconPath: mdiFlipToBack,
         schema: getGaugeStyleSchema(14)
       }
     ]

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -4,9 +4,10 @@ import { customElement, property, state } from "lit/decorators.js";
 import { ModernCircularGaugeBadgeConfig } from "./gauge-badge-config";
 import { NUMBER_ENTITY_DOMAINS, DEFAULT_MAX, DEFAULT_MIN } from "../const";
 import { fireEvent } from "../ha/common/dom/fire_event";
-import { mdiSegment } from "@mdi/js";
+import { mdiPalette, mdiSegment } from "@mdi/js";
 import { hexToRgb } from "../utils/color";
 import "../components/ha-form-mcg-list";
+import { getGaugeStyleSchema } from "../card/mcg-schema";
 import localize from "../localize/localize";
 
 const FORM = [
@@ -52,35 +53,68 @@ const FORM = [
         default: DEFAULT_MAX,
         schema: { number: { step: 0.1 } },
       },
+    ]
+  },
+  {
+    name: "badge_appearance",
+    type: "expandable",
+    iconPath: mdiPalette,
+    flatten: true,
+    schema: [
       {
-        name: "needle",
-        label: "gauge.needle_gauge",
-        selector: { boolean: {} },
+        name: "",
+        type: "grid",
+        schema: [
+          {
+            name: "needle",
+            selector: { boolean: {} },
+          },
+          {
+            name: "show_name",
+            default: false,
+            selector: { boolean: {} },
+          },
+          {
+            name: "show_state",
+            default: true,
+            selector: { boolean: {} },
+          },
+          {
+            name: "show_unit",
+            default: true,
+            selector: { boolean: {} },
+          },
+          {
+            name: "show_icon",
+            default: true,
+            selector: { boolean: {} },
+          },
+          {
+            name: "smooth_segments",
+            selector: { boolean: {} },
+          },
+          {
+            name: "start_from_zero",
+            helper: "start_from_zero",
+            selector: { boolean: {} }
+          },
+        ]
       },
       {
-        name: "show_name",
-        default: false,
-        selector: { boolean: {} },
+        name: "state_text",
+        helper: "state_text",
+        selector: { template: {} }
       },
       {
-        name: "show_state",
-        default: true,
-        selector: { boolean: {} },
+        name: "gauge_foreground_style",
+        type: "expandable",
+        schema: getGaugeStyleSchema(14)
       },
       {
-        name: "show_unit",
-        default: true,
-        selector: { boolean: {} },
-      },
-      {
-        name: "show_icon",
-        default: true,
-        selector: { boolean: {} },
-      },
-      {
-        name: "smooth_segments",
-        selector: { boolean: {} },
-      },
+        name: "gauge_background_style",
+        type: "expandable",
+        schema: getGaugeStyleSchema(14)
+      }
     ]
   },
   {
@@ -149,6 +183,7 @@ export class ModernCircularGaugeBadgeEditor extends LitElement {
       .data=${DATA}
       .schema=${FORM}
       .computeLabel=${this._computeLabel}
+      .computeHelper=${this._computeHelper}
       @value-changed=${this._valueChanged}
     ></ha-form>
     `;
@@ -156,6 +191,13 @@ export class ModernCircularGaugeBadgeEditor extends LitElement {
 
   private _computeLabel = (schema: any) => {
     return this.hass?.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`) || localize(this.hass, `editor.${schema.name}`);
+  };
+
+  private _computeHelper = (schema: any) => {
+    if ("helper" in schema) {
+      return localize(this.hass, `editor.helper.${schema.helper}`);
+    }
+    return undefined
   };
 
   private _valueChanged(ev: CustomEvent): void {

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -3,7 +3,7 @@ import { HomeAssistant } from "../ha/types";
 import { html, LitElement, nothing, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ModernCircularGaugeConfig } from "./type";
-import { mdiSegment, mdiPalette } from "@mdi/js";
+import { mdiSegment, mdiPalette, mdiGauge } from "@mdi/js";
 import { getEntityStyleSchema, getSecondarySchema, getTertiarySchema } from "./mcg-schema";
 import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS, RADIUS } from "../const";
 import memoizeOne from "memoize-one";
@@ -84,6 +84,7 @@ export class ModernCircularGaugeEditor extends LitElement {
         name: "primary_entity_style",
         type: "expandable",
         flatten: true,
+        iconPath: mdiGauge,
         schema: getEntityStyleSchema(true, RADIUS, "primary_label")
       },
         getSecondarySchema(showInnerGaugeOptions),

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -3,9 +3,9 @@ import { HomeAssistant } from "../ha/types";
 import { html, LitElement, nothing, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ModernCircularGaugeConfig } from "./type";
-import { mdiSegment, mdiInformationOutline, mdiNumeric3BoxOutline } from "@mdi/js";
-import { getSecondarySchema, getTertiarySchema } from "./mcg-schema";
-import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS } from "../const";
+import { mdiSegment, mdiPalette } from "@mdi/js";
+import { getEntityStyleSchema, getSecondarySchema, getTertiarySchema } from "./mcg-schema";
+import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS, RADIUS } from "../const";
 import memoizeOne from "memoize-one";
 import "../components/ha-form-mcg-list";
 import "../components/ha-form-mcg-template";
@@ -80,78 +80,76 @@ export class ModernCircularGaugeEditor extends LitElement {
           },
         ],
       },
+      {
+        name: "primary_entity_style",
+        type: "expandable",
+        flatten: true,
+        schema: getEntityStyleSchema(true, RADIUS, "primary_label")
+      },
         getSecondarySchema(showInnerGaugeOptions),
         getTertiarySchema(showTertiaryGaugeOptions),
       {
-        name: "header_position",
-        selector: {
-          select: {
-            options: [
-              { label: "Top", value: "top" },
-              { label: "Bottom", value: "bottom" },
-            ],
-            translation_key: "header_position_options",
-          },
-        },
-      },
-      {
-        name: "",
-        type: "grid",
+        name: "appearance",
+        type: "expandable",
+        flatten: true,
+        iconPath: mdiPalette,
         schema: [
           {
-            name: "needle",
-            selector: { boolean: {} },
-          },
-          {
-            name: "smooth_segments",
-            selector: { boolean: {} },
-          },
-          {
-            name: "show_header",
-            default: true,
-            selector: { boolean: {} },
-          },
-          {
-            name: "show_state",
-            default: true,
-            selector: { boolean: {} },
-          },
-          {
-            name: "show_unit",
-            default: true,
-            selector: { boolean: {} },
-          },
-          {
-            name: "show_icon",
-            default: true,
-            selector: { boolean: {} },
-          },
-          {
-            name: "adaptive_icon_color",
-            default: false,
-            selector: { boolean: {} },
-          },
-          {
-            name: "icon_entity",
-            default: "primary",
+            name: "header_position",
+            default: "bottom",
             selector: {
               select: {
                 options: [
-                  { value: "primary", label: "Primary" },
-                  { value: "secondary", label: "Secondary" },
-                  { value: "tertiary", label: "Tertiary" },
+                  { label: "Bottom", value: "bottom" },
+                  { label: "Top", value: "top" },
                 ],
-                mode: "dropdown",
-                translation_key: "icon_entity_options",
+                translation_key: "header_position_options",
+                mode: "box"
               },
             },
           },
           {
-            name: "adaptive_state_color",
-            default: false,
-            selector: { boolean: {} },
+            name: "",
+            type: "grid",
+            schema: [
+              {
+                name: "smooth_segments",
+                selector: { boolean: {} },
+              },
+              {
+                name: "show_header",
+                default: true,
+                selector: { boolean: {} },
+              },
+              {
+                name: "show_icon",
+                default: true,
+                selector: { boolean: {} },
+              },
+              {
+                name: "adaptive_icon_color",
+                default: false,
+                selector: { boolean: {} },
+              },
+              {
+                name: "icon_entity",
+                default: "primary",
+                helper: "icon_entity",
+                selector: {
+                  select: {
+                    options: [
+                      { value: "primary", label: "Primary" },
+                      { value: "secondary", label: "Secondary" },
+                      { value: "tertiary", label: "Tertiary" },
+                    ],
+                    mode: "dropdown",
+                    translation_key: "icon_entity_options",
+                  },
+                },
+              }
+            ],
           },
-        ],
+        ]
       },
       {
         name: "segments",
@@ -212,6 +210,7 @@ export class ModernCircularGaugeEditor extends LitElement {
         .schema=${schema}
         .computeLabel=${this._computeLabel}
         .localizeValue=${this._localizeValue}
+        .computeHelper=${this._computeHelper}
         @value-changed=${this._valueChanged}
     ></ha-form>
     `;
@@ -223,6 +222,13 @@ export class ModernCircularGaugeEditor extends LitElement {
 
   private _computeLabel = (schema: any) => {
     return this.hass?.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`) || localize(this.hass, `editor.${schema.name}`);
+  };
+
+  private _computeHelper = (schema: any) => {
+    if ("helper" in schema) {
+      return localize(this.hass, `editor.helper.${schema.helper}`);
+    }
+    return undefined
   };
 
   private _valueChanged(ev: CustomEvent): void {

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -1,4 +1,4 @@
-import { mdiNumeric2BoxOutline, mdiSegment, mdiNumeric3BoxOutline } from "@mdi/js";
+import { mdiNumeric2BoxOutline, mdiSegment, mdiNumeric3BoxOutline, mdiFlipToFront, mdiFlipToBack, mdiGauge } from "@mdi/js";
 import { NUMBER_ENTITY_DOMAINS, DEFAULT_MIN, DEFAULT_MAX, RADIUS, INNER_RADIUS, TERTIARY_RADIUS } from "../const";
 
 export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => [
@@ -141,12 +141,14 @@ export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadi
     name: "gauge_foreground_style",
     type: "expandable",
     disabled: !showGaugeOptions,
+    iconPath: mdiFlipToFront,
     schema: getGaugeStyleSchema(gaugeDefaultRadius == RADIUS ? 6 : 4)
   },
   {
     name: "gauge_background_style",
     type: "expandable",
     disabled: !showGaugeOptions,
+    iconPath: mdiFlipToBack,
     schema: getGaugeStyleSchema(gaugeDefaultRadius == RADIUS ? 6 : 4)
   }
 ];
@@ -190,6 +192,7 @@ export function getSecondarySchema(showGaugeOptions: boolean) {
         name: "secondary_entity_style",
         type: "expandable",
         flatten: true,
+        iconPath: mdiGauge,
         schema: getEntityStyleSchema(showGaugeOptions, INNER_RADIUS)
       },
       ...getSegmentsSchema(),
@@ -223,6 +226,7 @@ export function getTertiarySchema(showGaugeOptions: boolean) {
         name: "tertiary_entity_style",
         type: "expandable",
         flatten: true,
+        iconPath: mdiGauge,
         schema: getEntityStyleSchema(showGaugeOptions, TERTIARY_RADIUS)
       },
       ...getSegmentsSchema(),

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -1,77 +1,160 @@
 import { mdiNumeric2BoxOutline, mdiSegment, mdiNumeric3BoxOutline } from "@mdi/js";
-import { NUMBER_ENTITY_DOMAINS, DEFAULT_MIN, DEFAULT_MAX } from "../const";
+import { NUMBER_ENTITY_DOMAINS, DEFAULT_MIN, DEFAULT_MAX, RADIUS, INNER_RADIUS, TERTIARY_RADIUS } from "../const";
 
-export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => {
-  return [
-    {
-      name: "show_gauge",
-      selector: { select: {
-        options: [
-          { value: "none", label: "None" },
-          { value: "inner", label: "Inner gauge" },
-          { value: "outer", label: "Outer gauge" },
+export const getSecondaryGaugeSchema = (showGaugeOptions: boolean) => [
+  {
+    name: "show_gauge",
+    selector: { select: {
+      options: [
+        { value: "none", label: "None" },
+        { value: "inner", label: "Inner gauge" },
+        { value: "outer", label: "Outer gauge" },
+      ],
+      mode: "dropdown",
+      translation_key: "show_gauge_options",
+    }},
+  },
+  {
+    name: "",
+    type: "grid",
+    disabled: !showGaugeOptions,
+    schema: [
+      {
+        name: "min",
+        type: "mcg-template",
+        default: DEFAULT_MIN,
+        schema: { number: { step: 0.1 } },
+      },
+      {
+        name: "max",
+        type: "mcg-template",
+        default: DEFAULT_MAX,
+        schema: { number: { step: 0.1 } },
+      }
+    ],
+  },
+];
+
+const getSegmentsSchema = () => [
+  {
+    name: "segments",
+    type: "mcg-list",
+    iconPath: mdiSegment,
+    schema: [
+      {
+        name: "",
+        type: "grid",
+        column_min_width: "100px",
+        schema: [
+          {
+            name: "from",
+            type: "mcg-template",
+            required: true,
+            schema: { number: { step: 0.1 } },
+          },
+          {
+            name: "color",
+            type: "mcg-template",
+            required: true,
+            schema: { color_rgb: {} },
+          },
         ],
-        mode: "dropdown",
-        translation_key: "show_gauge_options",
-      }},
-    },
-    {
-      name: "",
-      type: "grid",
-      disabled: !showGaugeOptions,
-      schema: [
-        {
-          name: "min",
-          type: "mcg-template",
-          default: DEFAULT_MIN,
-          schema: { number: { step: 0.1 } },
-        },
-        {
-          name: "max",
-          type: "mcg-template",
-          default: DEFAULT_MAX,
-          schema: { number: { step: 0.1 } },
-        },
-        {
-          name: "needle",
-          selector: { boolean: {} },
-        },
-      ],
-    },
-    {
-      name: "segments",
-      type: "mcg-list",
-      iconPath: mdiSegment,
-      schema: [
-        {
-          name: "",
-          type: "grid",
-          column_min_width: "100px",
-          schema: [
-            {
-              name: "from",
-              type: "mcg-template",
-              required: true,
-              schema: { number: { step: 0.1 } },
-            },
-            {
-              name: "color",
-              type: "mcg-template",
-              required: true,
-              schema: { color_rgb: {} },
-            },
-          ],
-        },
-      ],
-    },
-  ];
-}
+      },
+    ],
+  },
+]
+
+export const getGaugeStyleSchema = (gaugeDefaultWidth: number = 6) => [
+  {
+    name: "",
+    type: "grid",
+    schema: [
+      {
+        name: "width",
+        default: gaugeDefaultWidth,
+        selector: { number: { step: "any", min: 0 } }
+      },
+      {
+        name: "color",
+        helper: "gauge_color",
+        selector: { text: {} }
+      },
+      {
+        name: "opacity",
+        default: 1,
+        selector: { number: { step: "any", min: 0, max: 1 } }
+      }
+    ]
+  }
+];
+
+export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadius: number = RADIUS, labelHelper: string = "label") => [
+  {
+    name: "label",
+    helper: labelHelper,
+    selector: { text: {} }
+  },
+  {
+    name: "",
+    type: "grid",
+    schema: [
+      {
+        name: "needle",
+        disabled: !showGaugeOptions,
+        selector: { boolean: {} },
+      },
+      {
+        name: "start_from_zero",
+        helper: "start_from_zero",
+        disabled: !showGaugeOptions,
+        selector: { boolean: {} }
+      },
+      {
+        name: "show_state",
+        default: true,
+        selector: { boolean: {} },
+      },
+      {
+        name: "show_unit",
+        default: true,
+        selector: { boolean: {} },
+      },
+      {
+        name: "adaptive_state_color",
+        default: false,
+        selector: { boolean: {} },
+      },
+    ]
+  },
+  {
+    name: "state_text",
+    helper: "state_text",
+    selector: { template: {} }
+  },
+  {
+    name: "gauge_radius",
+    default: gaugeDefaultRadius,
+    disabled: !showGaugeOptions,
+    selector: { number: { step: 1 } }
+  },
+  {
+    name: "gauge_foreground_style",
+    type: "expandable",
+    disabled: !showGaugeOptions,
+    schema: getGaugeStyleSchema(gaugeDefaultRadius == RADIUS ? 6 : 4)
+  },
+  {
+    name: "gauge_background_style",
+    type: "expandable",
+    disabled: !showGaugeOptions,
+    schema: getGaugeStyleSchema(gaugeDefaultRadius == RADIUS ? 6 : 4)
+  }
+];
 
 export function getSecondarySchema(showGaugeOptions: boolean) {
   return {
     name: "secondary",
     type: "expandable",
-    label: "Secondary info",
     iconPath: mdiNumeric2BoxOutline,
     schema: [
       {
@@ -99,25 +182,17 @@ export function getSecondarySchema(showGaugeOptions: boolean) {
               mode: "dropdown",
               translation_key: "state_size_options",
             }},
-          },
-          {
-            name: "show_state",
-            default: true,
-            selector: { boolean: {} },
-          },
-          {
-            name: "show_unit",
-            default: true,
-            selector: { boolean: {} },
-          },
-          {
-            name: "adaptive_state_color",
-            default: false,
-            selector: { boolean: {} },
-          },
+          }
         ],
       },
       ...getSecondaryGaugeSchema(showGaugeOptions),
+      {
+        name: "secondary_entity_style",
+        type: "expandable",
+        flatten: true,
+        schema: getEntityStyleSchema(showGaugeOptions, INNER_RADIUS)
+      },
+      ...getSegmentsSchema(),
       {
         name: "tap_action",
         selector: { ui_action: {} },
@@ -143,28 +218,14 @@ export function getTertiarySchema(showGaugeOptions: boolean) {
         name: "unit",
         selector: { text: {} },
       },
-      {
-        name: "",
-        type: "grid",
-        schema: [
-          {
-            name: "show_state",
-            default: true,
-            selector: { boolean: {} },
-          },
-          {
-            name: "show_unit",
-            default: true,
-            selector: { boolean: {} },
-          },
-          {
-            name: "adaptive_state_color",
-            default: false,
-            selector: { boolean: {} },
-          },
-        ],
-      },
       ...getSecondaryGaugeSchema(showGaugeOptions),
+      {
+        name: "tertiary_entity_style",
+        type: "expandable",
+        flatten: true,
+        schema: getEntityStyleSchema(showGaugeOptions, TERTIARY_RADIUS)
+      },
+      ...getSegmentsSchema(),
       {
         name: "tap_action",
         selector: { ui_action: {} },

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -13,7 +13,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { actionHandler } from "../utils/action-handler-directive";
-import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS, MAX_ANGLE } from "../const";
+import { DEFAULT_MIN, DEFAULT_MAX, NUMBER_ENTITY_DOMAINS, MAX_ANGLE, RADIUS, INNER_RADIUS, TERTIARY_RADIUS } from "../const";
 import { RenderTemplateResult, subscribeRenderTemplate } from "../ha/data/ws-templates";
 import { isTemplate } from "../utils/template";
 import "../components/modern-circular-gauge-element";
@@ -21,9 +21,6 @@ import "../components/modern-circular-gauge-state";
 import "../components/modern-circular-gauge-icon";
 
 const ROTATE_ANGLE = 360 - MAX_ANGLE / 2 - 90;
-const RADIUS = 47;
-const INNER_RADIUS = 42;
-const TERTIARY_RADIUS = 37;
 
 const path = svgArc({
   x: 0,

--- a/src/const.ts
+++ b/src/const.ts
@@ -2,4 +2,8 @@ export const DEFAULT_MIN = 0;
 export const DEFAULT_MAX = 100;
 export const MAX_ANGLE = 270;
 
+export const RADIUS = 47;
+export const INNER_RADIUS = 42;
+export const TERTIARY_RADIUS = 37;
+
 export const NUMBER_ENTITY_DOMAINS = ["sensor", "number", "counter", "input_number"];

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -38,7 +38,7 @@
       "label": "Text displayed under the state",
       "gauge_color": "Accepts hex, rgb, CSS variables or \"adaptive\" for segmented style",
       "icon_entity": "Select which entity to use for icon selection and coloring",
-      "state_text": "Overrides displayed state without overriding gauge data"
+      "state_text": "Overrides displayed state without overriding gauge data, accepts template"
     },
     "header_position_options": {
       "options": {

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -20,6 +20,26 @@
     "label": "Label",
     "switch_to_form": "Switch To Form",
     "switch_to_template": "Switch To Template",
+    "start_from_zero": "Start from zero",
+    "gauge_radius": "Gauge radius",
+    "width": "Width",
+    "opacity": "Opacity",
+    "gauge_foreground_style": "Gauge foreground style",
+    "gauge_background_style": "Gauge background style",
+    "appearance": "Card appearance",
+    "badge_appearance": "Badge appearance",
+    "state_text": "State text",
+    "primary_entity_style": "Entity style",
+    "secondary_entity_style": "Entity style",
+    "tertiary_entity_style": "Entity style",
+    "helper": {
+      "start_from_zero": "Gauge starts from zero instead of min",
+      "primary_label": "Text displayed under the main state when secondary state size is set to big",
+      "label": "Text displayed under the state",
+      "gauge_color": "Accepts hex, rgb, CSS variables or \"adaptive\" for segmented style",
+      "icon_entity": "Select which entity to use for icon selection and coloring",
+      "state_text": "Overrides displayed state without overriding gauge data"
+    },
     "header_position_options": {
       "options": {
         "top": "Top",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -20,6 +20,26 @@
     "label": "Etykieta",
     "switch_to_form": "Przełącz na Selektor",
     "switch_to_template": "Przełącz na Template",
+    "start_from_zero": "Rozpocznij od zera",
+    "gauge_radius": "Promień wskaźnika",
+    "width": "Szerokość",
+    "opacity": "Nieprzezroczystość",
+    "gauge_foreground_style": "Styl wskaźnika",
+    "gauge_background_style": "Styl tła wskaźnika",
+    "appearance": "Wygląd karty",
+    "badge_appearance": "Wygląd odznaki",
+    "state_text": "Tekst stanu",
+    "primary_entity_style": "Styl encji",
+    "secondary_entity_style": "Styl encji",
+    "tertiary_entity_style": "Styl encji",
+    "helper": {
+      "start_from_zero": "Wskaźnik rozpoczyna się od zera zamiast od minimum",
+      "primary_label": "Tekst wyświetlony pod głównym stanem, gdy rozmiar stanu informacji drugorzędnej jest duży",
+      "label": "Tekst wyświetlony pod stanem",
+      "gauge_color": "Przyjmuje wartości hex, rgb, zmienne CSS lub \"adaptive\" dla stylu segmentów kolorów",
+      "icon_entity": "Wybierz encję, której chcesz użyć do wyboru ikon i ich kolorowania",
+      "state_text": "Nadpisuje wyświetlany stan bez nadpisywania danych wskaźnika"
+    },
     "header_position_options": {
       "options": {
         "top": "Na górze",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -38,7 +38,7 @@
       "label": "Tekst wyświetlony pod stanem",
       "gauge_color": "Przyjmuje wartości hex, rgb, zmienne CSS lub \"adaptive\" dla stylu segmentów kolorów",
       "icon_entity": "Wybierz encję, której chcesz użyć do wyboru ikon i ich kolorowania",
-      "state_text": "Nadpisuje wyświetlany stan bez nadpisywania danych wskaźnika"
+      "state_text": "Nadpisuje wyświetlany stan bez nadpisywania danych wskaźnika, akceptuje template"
     },
     "header_position_options": {
       "options": {


### PR DESCRIPTION
Adds some of the YAML only configs (`label`, `state_text`, `start_from_zero`, `gauge_radius`, `gauge_background_style`, `gauge_foreground_style`) to visual editor, reorganizes editor layout by moving some of the configs to a collapsed sections, adds small helper text under some of the configs to hopefully better explain their function.

<img width="1034" height="897" alt="brave_bfsYEKZWaE" src="https://github.com/user-attachments/assets/b80c5821-0831-48aa-86fb-9834fb0cfb1d" /><img width="1035" height="900" alt="brave_u1ts2cftO9" src="https://github.com/user-attachments/assets/f8201e70-4600-48e7-a549-5ab1e687134f" />
