### PR TITLE
fix: card errors out when using template primary entity without name

### DIFF
--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -212,7 +212,7 @@ export class ModernCircularGauge extends LitElement {
       <div class="header" style=${styleMap({ "--gauge-header-font-size": this._config.header_font_size ? `${this._config.header_font_size}px` : undefined,
         "transform": this._config.header_offset ? `translate(0, ${this._config.header_offset}px)` : undefined })}>
         <p class="name">
-          ${this._templateResults?.name?.result ?? (isTemplate(String(this._config.name)) ? "" : this._config.name) ?? stateObj.attributes.friendly_name ?? ''}
+          ${this._templateResults?.name?.result ?? (isTemplate(String(this._config.name)) ? "" : this._config.name) ?? attributes ? attributes.friendly_name : ""}
         </p>
       </div>
       ` : nothing}


### PR DESCRIPTION
This fixes issue when using template primary entity without specifying name.