### PR TITLE
fix: card is ignoring name config

### DIFF
--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -212,7 +212,7 @@ export class ModernCircularGauge extends LitElement {
       <div class="header" style=${styleMap({ "--gauge-header-font-size": this._config.header_font_size ? `${this._config.header_font_size}px` : undefined,
         "transform": this._config.header_offset ? `translate(0, ${this._config.header_offset}px)` : undefined })}>
         <p class="name">
-          ${this._templateResults?.name?.result ?? (isTemplate(String(this._config.name)) ? "" : this._config.name) ?? attributes ? attributes.friendly_name : ""}
+          ${this._templateResults?.name?.result ?? (isTemplate(String(this._config.name)) ? "" : this._config.name) ?? (attributes ? attributes.friendly_name : "")}
         </p>
       </div>
       ` : nothing}


### PR DESCRIPTION
Fixes card not respecting name config, in short I forgot to add brackets around new template check that I implemented before full release.