### PR TITLE
feat: combined gauge mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Templates are supported on selected options, configurable via `yaml` or visual e
 | icon_vertical_position | `number` | Optional | Icon vertical position in % (50% indicates center)
 | min | `number` or `string` | `0` | Minimum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)|✅
 | max | `number` or `string` | `100` | Maximum gauge value. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/) see [example](#gauge-with-templated-additional-info-and-segments)|✅
+| combine_gauges | `boolean` | Optional | Combines primary and secondary entity into one gauge, useful for comparing two values. Only available in full gauge type. Tertiary entity is not supported
 | unit | `string` | Optional | Custom unit
 | decimals | `number` | Optional | Adjusts decimal places
 | label | `string` | Optional | Label under the state, only used when `state_size` is set to `big`, see [secondary](#secondary-entity-object)

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -172,6 +172,13 @@ export class ModernCircularGaugeEditor extends LitElement {
                     translation_key: "icon_entity_options",
                   },
                 },
+              },
+              {
+                name: "combine_gauges",
+                default: false,
+                disabled: gaugeType !== "full",
+                helper: "combine_gauges",
+                selector: { boolean: {} },
               }
             ],
           },

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -227,7 +227,7 @@ export class ModernCircularGauge extends LitElement {
       secondsUntil = getTimerRemainingSeconds(stateObj!);
     }
 
-    if (this._config.combine_gauges) {
+    if (this._config.combine_gauges && this._config.gauge_type === "full") {
       calculatedMax = this._getEntityStatesSum();
     }
 
@@ -245,7 +245,7 @@ export class ModernCircularGauge extends LitElement {
     const max = Number(this._templateResults?.max?.result ?? this._config.max ?? calculatedMax) || DEFAULT_MAX;
 
     const stateOverride = 
-      this._config.combine_gauges 
+      this._config.combine_gauges && this._config.gauge_type === "full" 
       ? this._getEntityStatesSum()
       : (this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : (this._config.state_text || undefined)));
 
@@ -301,11 +301,11 @@ export class ModernCircularGauge extends LitElement {
             .needle=${this._config.needle}
             .startFromZero=${this._config.start_from_zero}
             .rotateGauge=${this._config.rotate_gauge}
-            .linePadding=${this._config?.combine_gauges ? this._config.gauge_type == "full" ? 7.5 : 3.25 : 0}
-            .lineOffset=${this._config?.combine_gauges ? this._config.gauge_type == "full" ? 3.25 : 0 : 0}
+            .linePadding=${this._config.combine_gauges && this._config.gauge_type === "full" ? 7.5 : 0}
+            .lineOffset=${this._config.combine_gauges && this._config.gauge_type === "full" ?  3.25 : 0}
           ></modern-circular-gauge-element>
           ${typeof this._config.secondary != "string" ? 
-          (this._config.secondary?.show_gauge && this._config.secondary?.show_gauge != "none") || this._config.combine_gauges ?
+          (this._config.secondary?.show_gauge && this._config.secondary?.show_gauge != "none") || (this._config.combine_gauges && this._config.gauge_type === "full") ?
           this._renderSecondaryGauge()
           : nothing
           : nothing}
@@ -587,7 +587,7 @@ export class ModernCircularGauge extends LitElement {
       return html``;
     }
     
-    if (secondaryObj.show_gauge == "inner" || this._config?.combine_gauges) {
+    if (secondaryObj.show_gauge == "inner" || (this._config?.combine_gauges && this._config.gauge_type === "full")) {
       if (!stateObj && templatedState === undefined) {
         return html`
         <modern-circular-gauge-element
@@ -614,7 +614,7 @@ export class ModernCircularGauge extends LitElement {
         secondsUntil = getTimerRemainingSeconds(stateObj);
       }
 
-      if (this._config?.combine_gauges) {
+      if (this._config?.combine_gauges && this._config.gauge_type === "full") {
         let combinedStates = 0;
         this._entityStates.forEach((_, key) => {
           combinedStates += Number(this._getEntityState(key)) ?? 0;
@@ -634,7 +634,7 @@ export class ModernCircularGauge extends LitElement {
         .min=${min}
         .max=${max}
         .value=${numberState}
-        .radius=${this._config?.combine_gauges ? (this._config?.gauge_radius ?? RADIUS) : (secondaryObj.gauge_radius ?? INNER_RADIUS)}
+        .radius=${this._config?.combine_gauges && this._config.gauge_type === "full" ? (this._config?.gauge_radius ?? RADIUS) : (secondaryObj.gauge_radius ?? INNER_RADIUS)}
         .gaugeType=${this._config?.gauge_type}
         .segments=${segments}
         .smoothSegments=${this._config?.smooth_segments}
@@ -643,10 +643,10 @@ export class ModernCircularGauge extends LitElement {
         .needle=${secondaryObj?.needle}
         .startFromZero=${secondaryObj.start_from_zero}
         .rotateGauge=${this._config?.rotate_gauge}
-        .disableBackground=${this._config?.combine_gauges}
-        .flipGauge=${this._config?.combine_gauges}
-        .linePadding=${this._config?.combine_gauges ? this._config.gauge_type == "full" ? 7.5 : 3.25 : 0}
-        .lineOffset=${this._config?.combine_gauges ? this._config.gauge_type == "full" ? 3.25 : 3.25 : 0}
+        .disableBackground=${this._config?.combine_gauges && this._config.gauge_type === "full"}
+        .flipGauge=${this._config?.combine_gauges && this._config.gauge_type === "full"}
+        .linePadding=${this._config?.combine_gauges && this._config.gauge_type === "full" ? 7.5 : 0}
+        .lineOffset=${this._config?.combine_gauges && this._config.gauge_type === "full" ? 3.25 : 0}
       ></modern-circular-gauge-element>
       `;
     } else {
@@ -777,7 +777,7 @@ export class ModernCircularGauge extends LitElement {
   private _renderTertiaryState(): TemplateResult {
     const threeGauges = (typeof this._config?.secondary != "string" && this._config?.secondary?.show_gauge == "inner") && (typeof this._config?.tertiary != "string" && this._config?.tertiary?.show_gauge == "inner");
 
-    if (this._config?.combine_gauges) {
+    if (this._config?.combine_gauges && this._config.gauge_type === "full") {
       const templatedState = this._templateResults?.entity?.result;
       const stateObj = this._getEntityStateObj("primary");
       const numberState = Number(this._getEntityState("primary"));
@@ -786,7 +786,6 @@ export class ModernCircularGauge extends LitElement {
       const stateOverride = this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : (this._config.state_text || undefined));
       const segments = (this._templateResults?.segments?.result as unknown) as SegmentsConfig[] ?? this._config.segments;
       const segmentsLabel = this._getSegmentLabel(numberState, segments);
-      const halfStateBig = this._config?.gauge_type == "half" && typeof this._config.secondary != "string" && this._config.secondary?.state_size == "big";
 
       return html`
       <modern-circular-gauge-state
@@ -796,16 +795,16 @@ export class ModernCircularGauge extends LitElement {
           hasDoubleClick: hasAction(this._config.double_tap_action),
         })}
         class=${classMap({ "preview": this._inCardPicker! })}
-        style=${styleMap({ "--state-text-color-override": this._config.adaptive_state_color ? "var(--gauge-color)" : undefined , "--state-font-size-override": this._config.state_font_size ? `${this._config.state_font_size}px` : (halfStateBig ? `15px` : undefined) })}
+        style=${styleMap({ "--state-text-color-override": this._config.adaptive_state_color ? "var(--gauge-color)" : undefined , "--state-font-size-override": this._config.state_font_size ? `${this._config.state_font_size}px` : undefined })}
         .hass=${this.hass}
         .stateObj=${stateObj}
         .entityAttribute=${this._config.attribute}
         .stateOverride=${(segmentsLabel || stateOverride) ?? templatedState}
         .unit=${unit}
-        .verticalOffset=${this._config?.gauge_type == "half" ? (!this._hasSecondary ? -28 : (threeGauges ? -29 : -31)) : -19}
+        .verticalOffset=${-19}
         .stateMargin=${this._stateMargin}
         .showUnit=${this._config.show_unit ?? true}
-        .label=${this._config?.gauge_type == "half" ? "" : this._config.label}
+        .label=${this._config.label}
         .gaugeType=${this._config?.gauge_type}
         .labelFontSize=${this._config.label_font_size}
         .showSeconds=${this._config.show_seconds}

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -294,6 +294,8 @@ export class ModernCircularGauge extends LitElement {
             .needle=${this._config.needle}
             .startFromZero=${this._config.start_from_zero}
             .rotateGauge=${this._config.rotate_gauge}
+            .linePadding=${this._config?.combine_gauges ? this._config.gauge_type == "full" ? 7.5 : 3.25 : 0}
+            .lineOffset=${this._config?.combine_gauges ? this._config.gauge_type == "full" ? 3.25 : 0 : 0}
           ></modern-circular-gauge-element>
           ${typeof this._config.secondary != "string" ? 
           (this._config.secondary?.show_gauge && this._config.secondary?.show_gauge != "none") || this._config.combine_gauges ?
@@ -632,10 +634,12 @@ export class ModernCircularGauge extends LitElement {
         .foregroundStyle=${secondaryObj?.gauge_foreground_style}
         .backgroundStyle=${secondaryObj?.gauge_background_style}
         .needle=${secondaryObj?.needle}
-        .startFromZero=${secondaryObj.start_from_zero || this._config?.combine_gauges}
+        .startFromZero=${secondaryObj.start_from_zero}
         .rotateGauge=${this._config?.rotate_gauge}
         .disableBackground=${this._config?.combine_gauges}
         .flipGauge=${this._config?.combine_gauges}
+        .linePadding=${this._config?.combine_gauges ? this._config.gauge_type == "full" ? 7.5 : 3.25 : 0}
+        .lineOffset=${this._config?.combine_gauges ? this._config.gauge_type == "full" ? 3.25 : 3.25 : 0}
       ></modern-circular-gauge-element>
       `;
     } else {

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -50,6 +50,8 @@ export interface GaugeElementConfig {
 
 export type GaugeType = "standard" | "half" | "full";
 
+export type EntityNames = "primary" | "secondary" | "tertiary";
+
 export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     entity: string;
     attribute?: string;
@@ -62,6 +64,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     min?: number | string;
     max?: number | string;
     show_seconds?: boolean;
+    combine_gauges?: boolean;
     gauge_type?: GaugeType;
     rotate_gauge?: boolean;
     unit?: string;

--- a/src/components/modern-circular-gauge-element.ts
+++ b/src/components/modern-circular-gauge-element.ts
@@ -36,6 +36,12 @@ export class ModernCircularGaugeElement extends LitElement {
 
   @property({ type: Boolean }) public error = false;
 
+  @property({ type: Boolean }) public disableBackground = false;
+
+  @property({ type: Number }) public gaugeRotationOffset = 0;
+
+  @property({ type: Boolean }) public flipGauge = false;
+
   @state() private _updated = false;
 
   @state() private _path?: string;
@@ -93,8 +99,10 @@ export class ModernCircularGaugeElement extends LitElement {
       </svg>
       `
     } else {
-      const current = this.needle ? undefined : currentDashArc(this.value, this.min, this.max, this.radius, this.startFromZero, this._maxAngle);
-      const needle = this.needle ? strokeDashArc(this.value, this.value, this.min, this.max, this.radius, this._maxAngle) : undefined;
+      const min = this.flipGauge ? -this.max : this.min;
+      const max = this.flipGauge ? this.min : this.max;
+      const current = this.needle ? undefined : currentDashArc(this.value * (this.flipGauge ? -1.0 : 1.0), min, max, this.radius, this.startFromZero, this._maxAngle);
+      const needle = this.needle ? strokeDashArc(this.value, this.value, min, max, this.radius, this._maxAngle) : undefined;
       
       return html`
         <svg viewBox="-50 -50 100 ${this.gaugeType == "half" ? 50 : 100}" preserveAspectRatio="xMidYMid"
@@ -116,28 +124,32 @@ export class ModernCircularGaugeElement extends LitElement {
                 />
                 ` : nothing}
               </mask>
+              ${!this.disableBackground ? svg`
               <mask id="gradient-path">
                 ${renderPath("arc", this._path, undefined, styleMap({ "stroke": "white", "stroke-width": this.backgroundStyle?.width ? `${this.backgroundStyle?.width}px` : undefined }))}
               </mask>
+              `: nothing}
               <mask id="gradient-current-path">
-                ${current ? renderPath("arc current", this._path, current, styleMap({ "stroke": "white", "visibility": this.value <= this.min && this.min >= 0 ? "hidden" : "visible" })) : nothing}
+                ${current ? renderPath("arc current", this._path, current, styleMap({ "stroke": "white", "visibility": this.value <= min && min >= 0 ? "hidden" : "visible" })) : nothing}
               </mask>
             </defs>
+            ${!this.disableBackground ? svg`
             <g class="background" mask=${ifDefined(needle ? "url(#needle-border-mask)" : undefined)} style=${styleMap({ "opacity": this.backgroundStyle?.opacity,
               "--gauge-stroke-width": this.backgroundStyle?.width ? `${this.backgroundStyle?.width}px` : undefined })}>
               ${renderPath("arc clear", this._path, undefined, styleMap({ "stroke": this.backgroundStyle?.color && this.backgroundStyle.color != "adaptive" ? this.backgroundStyle.color : undefined }))}
               ${this.segments && (needle || this.backgroundStyle?.color == "adaptive") ? svg`
               <g class="segments" mask=${ifDefined(this.smoothSegments ? "url(#gradient-path)" : undefined)}>
-                ${renderColorSegments(this.segments, this.min, this.max, this.radius, this.smoothSegments, this._maxAngle)}
+                ${renderColorSegments(this.segments, min, max, this.radius, this.smoothSegments, this._maxAngle)}
               </g>`
               : nothing
               }
             </g>
+            `: nothing}
             ${current ? this.foregroundStyle?.color == "adaptive" && this.segments ? svg`
             <g class="foreground-segments" mask="url(#gradient-current-path)" style=${styleMap({ "opacity": this.foregroundStyle?.opacity })}>
-              ${renderColorSegments(this.segments, this.min, this.max, this.radius, this.smoothSegments, this._maxAngle)}
+              ${renderColorSegments(this.segments, min, max, this.radius, this.smoothSegments, this._maxAngle)}
             </g>
-            ` : renderPath("arc current", this._path, current, styleMap({ "visibility": this.value <= this.min && this.min >= 0 ? "hidden" : "visible", "opacity": this.foregroundStyle?.opacity }))
+            ` : renderPath("arc current", this._path, current, styleMap({ "visibility": this.value <= min && min >= 0 ? "hidden" : "visible", "opacity": this.foregroundStyle?.opacity }))
             : nothing}
             ${needle ? svg`
             ${renderPath("needle", this._path, needle)}

--- a/src/components/modern-circular-gauge-element.ts
+++ b/src/components/modern-circular-gauge-element.ts
@@ -42,6 +42,10 @@ export class ModernCircularGaugeElement extends LitElement {
 
   @property({ type: Boolean }) public flipGauge = false;
 
+  @property({ type: Number }) public linePadding = 0;
+
+  @property({ type: Number }) public lineOffset = 0;
+
   @state() private _updated = false;
 
   @state() private _path?: string;
@@ -101,7 +105,7 @@ export class ModernCircularGaugeElement extends LitElement {
     } else {
       const min = this.flipGauge ? -this.max : this.min;
       const max = this.flipGauge ? this.min : this.max;
-      const current = this.needle ? undefined : currentDashArc(this.value * (this.flipGauge ? -1.0 : 1.0), min, max, this.radius, this.startFromZero, this._maxAngle);
+      const current = this.needle ? undefined : currentDashArc(this.value * (this.flipGauge ? -1.0 : 1.0), min, max, this.radius, (this.startFromZero || this.flipGauge), this._maxAngle, this.linePadding, this.lineOffset);
       const needle = this.needle ? strokeDashArc(this.value, this.value, min, max, this.radius, this._maxAngle) : undefined;
       
       return html`
@@ -149,7 +153,7 @@ export class ModernCircularGaugeElement extends LitElement {
             <g class="foreground-segments" mask="url(#gradient-current-path)" style=${styleMap({ "opacity": this.foregroundStyle?.opacity })}>
               ${renderColorSegments(this.segments, min, max, this.radius, this.smoothSegments, this._maxAngle)}
             </g>
-            ` : renderPath("arc current", this._path, current, styleMap({ "visibility": this.value <= min && min >= 0 ? "hidden" : "visible", "opacity": this.foregroundStyle?.opacity }))
+            ` : renderPath("arc current", this._path, current, styleMap({ "visibility": (this.value <= min && min >= 0) || (this.flipGauge && this.value <= this.min) ? "hidden" : "visible", "opacity": this.foregroundStyle?.opacity }))
             : nothing}
             ${needle ? svg`
             ${renderPath("needle", this._path, needle)}

--- a/src/components/modern-circular-gauge-state.ts
+++ b/src/components/modern-circular-gauge-state.ts
@@ -49,7 +49,7 @@ export class ModernCircularGaugeState extends LitElement {
     super.connectedCallback();
     if (this.stateObj) {
       const domain = computeStateDomain(this.stateObj);
-      if (this.stateObj?.attributes.device_class === "timestamp" ||
+      if (this.stateObj?.attributes?.device_class === "timestamp" ||
         TIMESTAMP_STATE_DOMAINS.includes(domain)
       ) {
         this._startInterval();

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -37,6 +37,7 @@
     "show_entity_picture": "Show entity picture",
     "show_seconds": "Show seconds",
     "rotate_gauge": "Rotate gauge",
+    "combine_gauges": "Combine primary and secondary entity",
     "helper": {
       "start_from_zero": "Gauge starts from zero instead of min",
       "primary_label": "Text displayed under the main state when secondary state size is set to big",
@@ -46,7 +47,8 @@
       "state_text": "Overrides displayed state without overriding gauge data, accepts template",
       "half_gauge_icon_unavailable": "Icon is unavailable when gauge type is set to half",
       "show_seconds": "Show seconds in time-based states",
-      "rotate_gauge": "Rotates the full gauge type 180 degrees"
+      "rotate_gauge": "Rotates the full gauge type 180 degrees",
+      "combine_gauges": "Combines primary and secondary entity into one full gauge, only available when gauge type is set to full"
     },
     "header_position_options": {
       "options": {

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -37,6 +37,7 @@
     "show_entity_picture": "Pokaż zdjęcie encji",
     "show_seconds": "Pokaż sekundy",
     "rotate_gauge": "Obróć wskaźnik",
+    "combine_gauges": "Połącz encję pierwszorzędną i drugorzędną",
     "helper": {
       "start_from_zero": "Wskaźnik rozpoczyna się od zera zamiast od minimum",
       "primary_label": "Tekst wyświetlony pod głównym stanem, gdy rozmiar stanu informacji drugorzędnej jest duży",
@@ -46,7 +47,8 @@
       "state_text": "Nadpisuje wyświetlany stan bez nadpisywania danych wskaźnika, akceptuje template",
       "half_gauge_icon_unavailable": "Ikona jest niedostępna, gdy typ wskaźnika jest ustawiony na połówkę",
       "show_seconds": "Pokaż sekundy w stanach opartych na czasie",
-      "rotate_gauge": "Obraca pełny wskaźnik o 180 stopni"
+      "rotate_gauge": "Obraca pełny wskaźnik o 180 stopni",
+      "combine_gauges": "Łączy encję pierwszorzędną i drugorzędną w jeden pełny wskaźnik, dostępne tylko gdy typ wskaźnika jest ustawiony na pełny"
     },
     "header_position_options": {
       "options": {

--- a/src/utils/compute-state.ts
+++ b/src/utils/compute-state.ts
@@ -18,7 +18,7 @@ export function computeState(hass: HomeAssistant, stateObj: HassEntity, entityAt
     const domain = computeStateDomain(stateObj);
     let secondsUntil: number | undefined;
 
-    if (stateObj?.attributes.device_class === "timestamp" ||
+    if (stateObj?.attributes?.device_class === "timestamp" ||
       TIMESTAMP_STATE_DOMAINS.includes(domain)
     ) {
       const timestamp = new Date(stateObj.state);

--- a/src/utils/gauge.ts
+++ b/src/utils/gauge.ts
@@ -77,16 +77,17 @@ export const svgArc = (options: ArcOptions) => {
   ].join(" ");
 };
 
-export const strokeDashArc = (from: number, to: number, min: number, max: number, radius: number, maxAngle: number = MAX_ANGLE): [string, string] => {
+export const strokeDashArc = (from: number, to: number, min: number, max: number, radius: number, maxAngle: number = MAX_ANGLE, linePadding?: number, offset?: number): [string, string] => {
   const start = valueToPercentage(from, min, max);
   const end = valueToPercentage(to, min, max);
 
+  const padding = linePadding ? linePadding : 0;
   const track = (radius * 2 * Math.PI * maxAngle) / 360;
-  const arc = Math.max((end - start) * track, 0);
+  const arc = Math.max(((end - start) * track) - padding, 0);
   const arcOffset = start * track - 0.5;
 
-  const strokeDasharray = `${arc} ${track - arc}`;
-  const strokeDashOffset = `-${arcOffset}`;
+  const strokeDasharray = `${arc} ${(track - arc) + padding}`;
+  const strokeDashOffset = `-${arcOffset + (offset ?? 0)}`;
   return [strokeDasharray, strokeDashOffset];
 }
 
@@ -98,11 +99,11 @@ export const valueToPercentage = (value: number, min: number, max: number) => {
   return (clamp(value, min, max) - min) / (max - min);
 }
 
-export const currentDashArc = (value: number, min: number, max: number, radius: number, startFromZero?: boolean, maxAngle: number = MAX_ANGLE): [string, string] => {
+export const currentDashArc = (value: number, min: number, max: number, radius: number, startFromZero?: boolean, maxAngle: number = MAX_ANGLE, linePadding?: number, offset?: number): [string, string] => {
   if (startFromZero) {
-    return strokeDashArc(value > 0 ? 0 : value, value > 0 ? value : 0, min, max, radius, maxAngle);
+    return strokeDashArc(value > 0 ? 0 : value, value > 0 ? value : 0, min, max, radius, maxAngle, linePadding, offset);
   } else {
-    return strokeDashArc(min, value, min, max, radius, maxAngle);
+    return strokeDashArc(min, value, min, max, radius, maxAngle, linePadding, offset);
   }
 }
 


### PR DESCRIPTION
Adds new config `combine_gauges` which makes gauge display primary and secondary entities on one gauge line e.g. displaying energy used from grid and from solar.
In this mode, primary entity is displayed on the top of the center state display just like tertiary entity. Secondary entity is displayed normally. Center state display shows sum of the two entities.
Tertiary entity is not supported and this mode is only available in full gauge type.
<img width="254" height="257" alt="gauge" src="https://github.com/user-attachments/assets/e46b6f26-efc7-451b-ae74-5d658494a8d1" />
