### PR TITLE
perf: smarter card and badge updates

### DIFF
--- a/src/components/mcg-badge-state.ts
+++ b/src/components/mcg-badge-state.ts
@@ -24,39 +24,12 @@ export class McgBadgeState extends LitElement {
 
   @property({ type: Boolean }) public showSeconds = true;
 
-  private _interval?: any;
-
   connectedCallback(): void {
     super.connectedCallback();
-    if (this.stateObj) {
-      const domain = computeStateDomain(this.stateObj);
-      if (this.stateObj?.attributes.device_class === "timestamp" ||
-        TIMESTAMP_STATE_DOMAINS.includes(domain)
-      ) {
-        this._startInterval();
-      }
-    }
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
-    this._clearInterval();
-  }
-
-  private _startInterval(): void {
-    if (this._interval) {
-      clearInterval(this._interval);
-    }
-    this._interval = setInterval(() => {
-      this.requestUpdate();
-    }, (this.showSeconds ?? true) ? 1000 : 60000);
-  }
-
-  private _clearInterval(): void {
-    if (this._interval) {
-      clearInterval(this._interval);
-      this._interval = undefined;
-    }
   }
 
   protected render(): TemplateResult {

--- a/src/components/modern-circular-gauge-state.ts
+++ b/src/components/modern-circular-gauge-state.ts
@@ -43,37 +43,12 @@ export class ModernCircularGaugeState extends LitElement {
 
   @state() private _updated = false;
 
-  private _interval?: any;
-
   connectedCallback(): void {
     super.connectedCallback();
-    if (this.stateObj) {
-      const domain = computeStateDomain(this.stateObj);
-      if (this.stateObj?.attributes?.device_class === "timestamp" ||
-        TIMESTAMP_STATE_DOMAINS.includes(domain)
-      ) {
-        this._startInterval();
-      }
-    }
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
-    this._clearInterval();
-  }
-
-  private _startInterval() {
-    this._clearInterval();
-    this._interval = setInterval(() => {
-      this.requestUpdate();
-    }, (this.showSeconds ?? true) ? 1000 : 60000);
-  }
-
-  private _clearInterval() {
-    if (this._interval) {
-      clearInterval(this._interval);
-      this._interval = undefined;
-    }
   }
 
   protected firstUpdated(_changedProperties: PropertyValues): void {

--- a/src/utils/compare-hass.ts
+++ b/src/utils/compare-hass.ts
@@ -1,0 +1,17 @@
+import { HomeAssistant } from "../ha/types";
+
+export function compareHass(
+  oldHass: HomeAssistant | undefined,
+  newHass: HomeAssistant,
+  entities: Set<string>
+): boolean {
+  if (!oldHass) {
+    return true;
+  }
+  for (const entityId of entities) {
+    if (oldHass.states[entityId] !== newHass.states[entityId]) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Introduces smarter card and badge updates. This reduces unnecessary updates with bigger Home Assistant instances. Updates are only performed when one of the used entities changes, excluding timestamp, timer or template entities. Before, card was updated every time any entity state was changed even entity that was not used in the card.