### PR TITLE
chore: remove flip_gauge selectors from entity style configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ Templates are supported on selected options, configurable via `yaml` or visual e
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | state_font_size | `number` | `10` or `24` | State size in px
 | state_text | `string` | Entity state | Displayed state override. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)|✅
-| rotate_gauge | `boolean`, | `false` | When true full gauge is rotated 180° so it starts from the top
 | gauge_radius | `number` | `42` | Gauge radius
 | gauge_background_style | `object` | Optional | Gauge background style, see [gauge element style object](#gauge-element-style-object)
 | gauge_foreground_style | `object` | Optional | Gauge foreground style, see [gauge element style object](#gauge-element-style-object)
@@ -178,7 +177,6 @@ Templates are supported on selected options, configurable via `yaml` or visual e
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | state_font_size | `number` | `10` | State size in px
 | state_text | `string` | Entity state | Displayed state override. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/)|✅
-| rotate_gauge | `boolean`, | `false` | When true full gauge is rotated 180° so it starts from the top
 | gauge_radius | `number` | `37` | Gauge radius
 | gauge_background_style | `object` | Optional | Gauge background style, see [gauge element style object](#gauge-element-style-object)
 | gauge_foreground_style | `object` | Optional | Gauge foreground style, see [gauge element style object](#gauge-element-style-object)

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -96,10 +96,10 @@ export class ModernCircularGaugeEditor extends LitElement {
         type: "expandable",
         flatten: true,
         iconPath: mdiGauge,
-        schema: getEntityStyleSchema(true, RADIUS, "primary_label", gaugeType === "full"),
+        schema: getEntityStyleSchema(true, RADIUS, "primary_label"),
       },
-        getSecondarySchema(showInnerGaugeOptions, gaugeType === "full", entities),
-        getTertiarySchema(showTertiaryGaugeOptions, gaugeType === "full", entities),
+        getSecondarySchema(showInnerGaugeOptions, entities),
+        getTertiarySchema(showTertiaryGaugeOptions, entities),
       {
         name: "appearance",
         type: "expandable",
@@ -177,7 +177,14 @@ export class ModernCircularGaugeEditor extends LitElement {
                 disabled: gaugeType !== "full",
                 helper: "combine_gauges",
                 selector: { boolean: {} },
-              }
+              },
+              {
+                name: "rotate_gauge",
+                default: false,
+                disabled: gaugeType !== "full",
+                helper: "rotate_gauge",
+                selector: { boolean: {} },
+              },
             ],
           },
           {

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -89,7 +89,7 @@ export const getGaugeStyleSchema = (gaugeDefaultWidth: number = 6) => [
   }
 ];
 
-export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadius: number = RADIUS, labelHelper: string = "label", fullGauge: boolean = false) => [
+export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadius: number = RADIUS, labelHelper: string = "label") => [
   {
     name: "label",
     helper: labelHelper,
@@ -132,13 +132,6 @@ export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadi
         selector: { boolean: {} },
       },
       {
-        name: "rotate_gauge",
-        default: false,
-        disabled: !showGaugeOptions || !fullGauge,
-        helper: "rotate_gauge",
-        selector: { boolean: {} },
-      },
-      {
         name: "decimals",
         selector: { number: { step: 1, min: 0 } },
       },
@@ -171,7 +164,7 @@ export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadi
   }
 ];
 
-export function getSecondarySchema(showGaugeOptions: boolean, fullGauge: boolean = false, entities?: Map<EntityNames, string>) {
+export function getSecondarySchema(showGaugeOptions: boolean, entities?: Map<EntityNames, string>) {
   return {
     name: "secondary",
     type: "expandable",
@@ -220,7 +213,7 @@ export function getSecondarySchema(showGaugeOptions: boolean, fullGauge: boolean
         type: "expandable",
         flatten: true,
         iconPath: mdiGauge,
-        schema: getEntityStyleSchema(showGaugeOptions, INNER_RADIUS, "label", fullGauge)
+        schema: getEntityStyleSchema(showGaugeOptions, INNER_RADIUS, "label")
       },
       ...getSegmentsSchema(),
       {
@@ -231,7 +224,7 @@ export function getSecondarySchema(showGaugeOptions: boolean, fullGauge: boolean
   }
 }
 
-export function getTertiarySchema(showGaugeOptions: boolean, fullGauge: boolean = false, entities?: Map<EntityNames, string>) {
+export function getTertiarySchema(showGaugeOptions: boolean, entities?: Map<EntityNames, string>) {
   return {
     name: "tertiary",
     type: "expandable",
@@ -263,7 +256,7 @@ export function getTertiarySchema(showGaugeOptions: boolean, fullGauge: boolean 
         type: "expandable",
         flatten: true,
         iconPath: mdiGauge,
-        schema: getEntityStyleSchema(showGaugeOptions, TERTIARY_RADIUS, "label", fullGauge)
+        schema: getEntityStyleSchema(showGaugeOptions, TERTIARY_RADIUS, "label")
       },
       ...getSegmentsSchema(),
       {

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -24,7 +24,6 @@ export interface BaseEntityConfig {
     state_font_size?: number;
     start_from_zero?: boolean;
     gauge_radius?: number;
-    rotate_gauge?: boolean;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;
     adaptive_state_color?: boolean;


### PR DESCRIPTION
`flip_gauge` was not supposed to be a per entity config but for some reason I made it appear as one. This moves `flip_gauge` to card appearance section and removes the config from secondary and tertiary docs.