### PR TITLE
fix: ignore tertiary entity when using combined mode

### DIFF
--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -34,7 +34,7 @@ export class ModernCircularGaugeEditor extends LitElement {
   }
 
   private _schema = memoizeOne(
-    (showInnerGaugeOptions: boolean, showTertiaryGaugeOptions: boolean, gaugeType: GaugeType, entities?: Map<EntityNames, string>) =>
+    (showInnerGaugeOptions: boolean, showTertiaryGaugeOptions: boolean, disableTertiary: boolean, gaugeType: GaugeType, entities?: Map<EntityNames, string>) =>
     [
       {
         name: "entity",
@@ -99,7 +99,7 @@ export class ModernCircularGaugeEditor extends LitElement {
         schema: getEntityStyleSchema(true, RADIUS, "primary_label"),
       },
         getSecondarySchema(showInnerGaugeOptions, entities),
-        getTertiarySchema(showTertiaryGaugeOptions, entities),
+        getTertiarySchema(disableTertiary, showTertiaryGaugeOptions, entities),
       {
         name: "appearance",
         type: "expandable",
@@ -264,6 +264,7 @@ export class ModernCircularGaugeEditor extends LitElement {
 
     const schema = this._schema(typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner",
       typeof this._config.tertiary != "string" && this._config.tertiary?.show_gauge == "inner",
+      this._config.combine_gauges === true && this._config.gauge_type === "full",
       this._config.gauge_type || "standard",
       entities
     );
@@ -274,13 +275,13 @@ export class ModernCircularGaugeEditor extends LitElement {
 
     return html`
     <ha-form
-        .hass=${this.hass}
-        .data=${DATA}
-        .schema=${schema}
-        .computeLabel=${this._computeLabel}
-        .localizeValue=${this._localizeValue}
-        .computeHelper=${this._computeHelper}
-        @value-changed=${this._valueChanged}
+      .hass=${this.hass}
+      .data=${DATA}
+      .schema=${schema}
+      .computeLabel=${this._computeLabel}
+      .localizeValue=${this._localizeValue}
+      .computeHelper=${this._computeHelper}
+      @value-changed=${this._valueChanged}
     ></ha-form>
     `;
   }

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -224,11 +224,13 @@ export function getSecondarySchema(showGaugeOptions: boolean, entities?: Map<Ent
   }
 }
 
-export function getTertiarySchema(showGaugeOptions: boolean, entities?: Map<EntityNames, string>) {
+export function getTertiarySchema(disableTertiary: boolean, showGaugeOptions: boolean, entities?: Map<EntityNames, string>) {
   return {
     name: "tertiary",
     type: "expandable",
     iconPath: mdiNumeric3BoxOutline,
+    disabled: disableTertiary,
+    helper: disableTertiary ? "tertiary_combined" : undefined,
     schema: [
       {
         name: "entity",

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -239,12 +239,12 @@ export class ModernCircularGauge extends LitElement {
     return undefined;
   }
 
-  private _getEntityStatesSum(): number {
+  private _getEntityStatesSum(ignoreTertiary: boolean = false): number {
     let combinedStates = 0;
     this._entityStates.forEach((_, key) => {
       if (key === "primary") {
         combinedStates += Number(this._getEntityState(key, this._config?.attribute)) ?? 0;
-      } else {
+      } else if (key === "secondary" || (key === "tertiary" && !ignoreTertiary)) {
         combinedStates += Number(this._getEntityState(key, typeof this._config?.[key] === "object" ? this._config?.[key].attribute : undefined)) ?? 0;
       }
     });
@@ -296,7 +296,7 @@ export class ModernCircularGauge extends LitElement {
     }
 
     if (this._config.combine_gauges && this._config.gauge_type === "full") {
-      calculatedMax = this._getEntityStatesSum();
+      calculatedMax = this._getEntityStatesSum(true);
     }
 
     const numberState = Number(templatedState ?? secondsUntil ?? entityState);
@@ -314,7 +314,7 @@ export class ModernCircularGauge extends LitElement {
 
     const stateOverride = 
       this._config.combine_gauges && this._config.gauge_type === "full" 
-      ? this._getEntityStatesSum()
+      ? this._getEntityStatesSum(true)
       : (this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : (this._config.state_text || undefined)));
 
     const iconCenter = !(this._config.show_state ?? false) && (this._config.show_icon ?? true);
@@ -690,7 +690,7 @@ export class ModernCircularGauge extends LitElement {
       }
 
       if (this._config?.combine_gauges && this._config.gauge_type === "full") {
-        calculatedMax = this._getEntityStatesSum();
+        calculatedMax = this._getEntityStatesSum(true);
       }
 
       

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -48,7 +48,8 @@
       "half_gauge_icon_unavailable": "Icon is unavailable when gauge type is set to half",
       "show_seconds": "Show seconds in time-based states",
       "rotate_gauge": "Rotates the full gauge type 180 degrees",
-      "combine_gauges": "Combines primary and secondary entity into one full gauge, only available when gauge type is set to full"
+      "combine_gauges": "Combines primary and secondary entity into one full gauge, only available when gauge type is set to full",
+      "tertiary_combined": "Tertiary entity is disabled when combining primary and secondary entity"
     },
     "header_position_options": {
       "options": {

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -48,7 +48,8 @@
       "half_gauge_icon_unavailable": "Ikona jest niedostępna, gdy typ wskaźnika jest ustawiony na połówkę",
       "show_seconds": "Pokaż sekundy w stanach opartych na czasie",
       "rotate_gauge": "Obraca pełny wskaźnik o 180 stopni",
-      "combine_gauges": "Łączy encję pierwszorzędną i drugorzędną w jeden pełny wskaźnik, dostępne tylko gdy typ wskaźnika jest ustawiony na pełny"
+      "combine_gauges": "Łączy encję pierwszorzędną i drugorzędną w jeden pełny wskaźnik, dostępne tylko gdy typ wskaźnika jest ustawiony na pełny",
+      "tertiary_combined": "Encja trzeciorzędna jest wyłączona podczas łączenia encji pierwszorzędnej i drugorzędnej"
     },
     "header_position_options": {
       "options": {


### PR DESCRIPTION
This fixes incorrect sum of the entities with `combine_gauges: true` and tertiary entity. 