### PR TITLE
fix: hide card overflow

### DIFF
--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -1243,6 +1243,7 @@ export class ModernCircularGauge extends LitElement {
       padding: 10px;
       flex-direction: column-reverse;
       align-items: center;
+      overflow: hidden;
     }
 
     ha-card.action {


### PR DESCRIPTION
This fixes card overflow when using high gauge radius or width by hiding it.