### PR TITLE
fix: convert color names to theme color

### DIFF
--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -194,16 +194,7 @@ export class ModernCircularGaugeBadgeEditor extends LitElement {
       return nothing;
     }
 
-    const DATA = {
-      ...this._config,
-      segments: this._config.segments?.map(value => {
-        let color = value.color;
-        if (typeof value.color === "string") {
-            color = hexToRgb(value.color) as any;
-        }
-        return { ...value, color };
-      })
-    };
+    const DATA = this._config;
 
     return html`
     <ha-form

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -24,6 +24,7 @@ import { getTimestampRemainingSeconds, getTimerRemainingSeconds } from "../utils
 import "../components/mcg-badge-state";
 import "../components/modern-circular-gauge-state";
 import { compareHass } from "../utils/compare-hass";
+import { computeCssColor } from "../ha/common/color/compute-color";
 
 const MAX_ANGLE = 270;
 const ROTATE_ANGLE = 360 - MAX_ANGLE / 2 - 90;
@@ -356,7 +357,7 @@ export class ModernCircularGaugeBadge extends LitElement {
         hasDoubleClick: hasAction(this._config.double_tap_action),
       })}
       .iconOnly=${content === undefined}
-      style=${styleMap({ "--gauge-color": gaugeForegroundStyle?.color && gaugeForegroundStyle?.color != "adaptive" ? gaugeForegroundStyle?.color : computeSegments(numberState, segments, this._config.smooth_segments, this), "--gauge-stroke-width": gaugeForegroundStyle?.width ? `${gaugeForegroundStyle?.width}px` : undefined })}
+      style=${styleMap({ "--gauge-color": gaugeForegroundStyle?.color && gaugeForegroundStyle?.color != "adaptive" ? computeCssColor(gaugeForegroundStyle?.color) : computeSegments(numberState, segments, this._config.smooth_segments, this), "--gauge-stroke-width": gaugeForegroundStyle?.width ? `${gaugeForegroundStyle?.width}px` : undefined })}
       .label=${label}
     >
       <div class=${classMap({ "container": true, "icon-only": content === undefined })} slot="icon">
@@ -379,7 +380,7 @@ export class ModernCircularGaugeBadge extends LitElement {
             <g mask="url(#needle-mask)">
               <g class="background" style=${styleMap({ "opacity": this._config.gauge_background_style?.opacity,
                 "--gauge-stroke-width": this._config.gauge_background_style?.width ? `${this._config.gauge_background_style?.width}px` : undefined })}>
-                ${renderPath("arc clear", path, undefined, styleMap({ "stroke": gaugeBackgroundStyle?.color && gaugeBackgroundStyle?.color != "adaptive" ? gaugeBackgroundStyle?.color : undefined }))}
+                ${renderPath("arc clear", path, undefined, styleMap({ "stroke": gaugeBackgroundStyle?.color && gaugeBackgroundStyle?.color != "adaptive" ? computeCssColor(gaugeBackgroundStyle?.color) : undefined }))}
                 ${this._config.segments && (this._config.needle || this._config.gauge_background_style?.color == "adaptive") ? svg`
                 <g class="segments" mask=${ifDefined(this._config.smooth_segments ? "url(#gradient-path)" : undefined)}>
                   ${renderColorSegments(segments, min, max, RADIUS, this._config?.smooth_segments)}

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -23,6 +23,7 @@ import { computeStateDomain } from "../ha/common/entity/compute_state_domain";
 import durationToSeconds from "../ha/common/datetime/duration_to_seconds";
 import { getTimerRemainingSeconds, getTimestampRemainingSeconds } from "../utils/timer_timestamp_utils";
 import { compareHass } from "../utils/compare-hass";
+import { computeCssColor } from "../ha/common/color/compute-color";
 
 registerCustomCard({
   type: "modern-circular-gauge",
@@ -357,7 +358,7 @@ export class ModernCircularGauge extends LitElement {
         class="container${classMap({ "dual-gauge": (typeof this._config.secondary != "string" && this._config.secondary?.show_gauge == "inner") || (typeof this._config.tertiary != "string" && this._config.tertiary?.show_gauge == "inner"),
           "half-gauge": this._config.gauge_type == "half", "full-gauge": this._config.gauge_type == "full" })}"
         style=${styleMap({ "--full-gauge-padding": this._config.show_header ? undefined : "0",
-          "--gauge-color": this._config.gauge_foreground_style?.color && this._config.gauge_foreground_style?.color != "adaptive" ? this._config.gauge_foreground_style?.color : computeSegments(numberState, segments, this._config.smooth_segments, this) })}
+          "--gauge-color": this._config.gauge_foreground_style?.color && this._config.gauge_foreground_style?.color != "adaptive" ? computeCssColor(this._config.gauge_foreground_style?.color) : computeSegments(numberState, segments, this._config.smooth_segments, this) })}
       >
         <div class="gauge-container">
           <modern-circular-gauge-element
@@ -520,7 +521,7 @@ export class ModernCircularGauge extends LitElement {
     <div class="icon-container">
       <modern-circular-gauge-icon
         class=${classMap({ "adaptive": !!this._config?.adaptive_icon_color })}
-        style=${styleMap({ "--gauge-color": gaugeForegroundStyle?.color && gaugeForegroundStyle.color != "adaptive" ? gaugeForegroundStyle.color : computeSegments(value, segments, this._config?.smooth_segments, this) })}
+        style=${styleMap({ "--gauge-color": gaugeForegroundStyle?.color && gaugeForegroundStyle.color != "adaptive" ? computeCssColor(gaugeForegroundStyle.color) : computeSegments(value, segments, this._config?.smooth_segments, this) })}
         .hass=${this.hass}
         .stateObj=${stateObj}
         .icon=${iconOverride}
@@ -818,7 +819,7 @@ export class ModernCircularGauge extends LitElement {
       }
 
       if (secondary.gauge_foreground_style?.color && secondary.gauge_foreground_style?.color != "adaptive") {
-        secondaryColor = secondary.gauge_foreground_style?.color;
+        secondaryColor = computeCssColor(secondary.gauge_foreground_style?.color);
       }
     }
 
@@ -943,7 +944,7 @@ export class ModernCircularGauge extends LitElement {
       }
 
       if (tertiary.gauge_foreground_style?.color && tertiary.gauge_foreground_style?.color != "adaptive") {
-        adaptiveColor = tertiary.gauge_foreground_style?.color;
+        adaptiveColor = computeCssColor(tertiary.gauge_foreground_style?.color);
       }
     }
 

--- a/src/components/modern-circular-gauge-element.ts
+++ b/src/components/modern-circular-gauge-element.ts
@@ -5,6 +5,7 @@ import { GaugeElementConfig, GaugeType, SegmentsConfig } from "../card/type";
 import { styleMap } from "lit/directives/style-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { svgArc, renderPath, currentDashArc, strokeDashArc, renderColorSegments, computeSegments } from "../utils/gauge";
+import { computeCssColor } from "../ha/common/color/compute-color";
 
 @customElement("modern-circular-gauge-element")
 export class ModernCircularGaugeElement extends LitElement {
@@ -94,11 +95,11 @@ export class ModernCircularGaugeElement extends LitElement {
       <svg viewBox="-50 -50 100 ${this.gaugeType == "half" ? 50 : 100}" preserveAspectRatio="xMidYMid"
         overflow="visible"
         style=${styleMap({ "--gauge-stroke-width": this.foregroundStyle?.width ? `${this.foregroundStyle?.width}px` : undefined,
-        "--gauge-color": this.foregroundStyle?.color && this.foregroundStyle?.color != "adaptive" ? this.foregroundStyle?.color : computeSegments(this.value, this.segments, this.smoothSegments, this) })}
+        "--gauge-color": this.foregroundStyle?.color && this.foregroundStyle?.color != "adaptive" ? computeCssColor(this.foregroundStyle?.color) : computeSegments(this.value, this.segments, this.smoothSegments, this) })}
       >
         <g transform="rotate(${this._rotateAngle})">
           ${!this.foregroundStyle?.color ? renderPath("dot border", this._path, current, styleMap({ "opacity": this.foregroundStyle?.opacity ?? 1, "stroke-width": this.foregroundStyle?.width })) : nothing}
-          ${renderPath("dot", this._path, current, styleMap({ "opacity": this.foregroundStyle?.opacity ?? 1, "stroke": this.foregroundStyle?.color, "stroke-width": this.foregroundStyle?.width }))}
+          ${renderPath("dot", this._path, current, styleMap({ "opacity": this.foregroundStyle?.opacity ?? 1, "stroke": computeCssColor(this.foregroundStyle?.color ?? ""), "stroke-width": this.foregroundStyle?.width }))}
         </g>
       </svg>
       `
@@ -112,7 +113,7 @@ export class ModernCircularGaugeElement extends LitElement {
         <svg viewBox="-50 -50 100 ${this.gaugeType == "half" ? 50 : 100}" preserveAspectRatio="xMidYMid"
           overflow="visible"
           style=${styleMap({ "--gauge-stroke-width": this.foregroundStyle?.width ? `${this.foregroundStyle?.width}px` : undefined,
-          "--gauge-color": this.foregroundStyle?.color && this.foregroundStyle?.color != "adaptive" ? this.foregroundStyle?.color : computeSegments(this.value, this.segments, this.smoothSegments, this) })}
+          "--gauge-color": this.foregroundStyle?.color && this.foregroundStyle?.color != "adaptive" ? computeCssColor(this.foregroundStyle?.color) : computeSegments(this.value, this.segments, this.smoothSegments, this) })}
         >
           <g transform="rotate(${this._rotateAngle})">
             <defs>
@@ -140,7 +141,7 @@ export class ModernCircularGaugeElement extends LitElement {
             ${!this.disableBackground ? svg`
             <g class="background" mask=${ifDefined(needle ? "url(#needle-border-mask)" : undefined)} style=${styleMap({ "opacity": this.backgroundStyle?.opacity,
               "--gauge-stroke-width": this.backgroundStyle?.width ? `${this.backgroundStyle?.width}px` : undefined })}>
-              ${renderPath("arc clear", this._path, undefined, styleMap({ "stroke": this.backgroundStyle?.color && this.backgroundStyle.color != "adaptive" ? this.backgroundStyle.color : undefined }))}
+              ${renderPath("arc clear", this._path, undefined, styleMap({ "stroke": this.backgroundStyle?.color && this.backgroundStyle.color != "adaptive" ? computeCssColor(this.backgroundStyle.color) : undefined }))}
               ${this.segments && (needle || this.backgroundStyle?.color == "adaptive") ? svg`
               <g class="segments" mask=${ifDefined(this.smoothSegments ? "url(#gradient-path)" : undefined)}>
                 ${renderColorSegments(this.segments, min, max, this.radius, this.smoothSegments, this._maxAngle)}

--- a/src/ha/common/color/compute-color.ts
+++ b/src/ha/common/color/compute-color.ts
@@ -1,0 +1,35 @@
+export const THEME_COLORS = new Set([
+  "primary",
+  "accent",
+  "disabled",
+  "red",
+  "pink",
+  "purple",
+  "deep-purple",
+  "indigo",
+  "blue",
+  "light-blue",
+  "cyan",
+  "teal",
+  "green",
+  "light-green",
+  "lime",
+  "yellow",
+  "amber",
+  "orange",
+  "deep-orange",
+  "brown",
+  "light-grey",
+  "grey",
+  "dark-grey",
+  "blue-grey",
+  "black",
+  "white",
+]);
+
+export function computeCssColor(color: string): string {
+  if (THEME_COLORS.has(color)) {
+    return `var(--${color}-color)`;
+  }
+  return color;
+}

--- a/src/utils/gauge.ts
+++ b/src/utils/gauge.ts
@@ -6,6 +6,7 @@ import { DirectiveResult } from "lit/directive";
 import { styleMap, StyleMapDirective } from "lit/directives/style-map.js";
 import { ClassMapDirective } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { computeCssColor } from "../ha/common/color/compute-color";
 
 type Vector = [number, number];
 type Matrix = [Vector, Vector];
@@ -137,7 +138,7 @@ export function renderSegmentsGradient(segments: SegmentsConfig[], min: number, 
     }
     sortedSegments.map((segment, index) => {
       const angle = getAngle(Number(segment.from), min, max, maxAngle) + angleOffset;
-      const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+      const color = typeof segment.color === "object" ? rgbToHex(segment.color) : computeCssColor(segment.color);
       gradient += `${color} ${angle}deg${index != sortedSegments.length - 1 ? "," : ""}`;
     });
     return [svg`
@@ -159,7 +160,7 @@ export function renderSegments(segments: SegmentsConfig[], min: number, max: num
       let roundEnd: TemplateResult | undefined;
       const startAngle = index === 0 ? 0 : getAngle(Number(segment.from), min, max, maxAngle);
       const angle = index === sortedSegments.length - 1 ? maxAngle : getAngle(Number(sortedSegments[index + 1].from), min, max, maxAngle);
-      const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+      const color = typeof segment.color === "object" ? rgbToHex(segment.color) : computeCssColor(segment.color);
       const segmentPath = svgArc({
         x: 0,
         y: 0,
@@ -196,14 +197,14 @@ export function computeSegments(numberState: number, segments: SegmentsConfig[] 
       if (segment && (numberState >= Number(segment.from) || i === 0) &&
         (i + 1 == sortedSegments?.length || numberState < Number(sortedSegments![i + 1].from))) {
           if (smooth_segments) {
-            let color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+            let color = typeof segment.color === "object" ? rgbToHex(segment.color) : computeCssColor(segment.color);
 
             if (color.includes("var(--") && element) {
               color = getComputedStyle(element).getPropertyValue(color.replace(/(var\()|(\))/g, "").trim());
             }
 
             const nextSegment = sortedSegments[i + 1] ? sortedSegments[i + 1] : segment;
-            let nextColor = typeof nextSegment.color === "object" ? rgbToHex(nextSegment.color) : nextSegment.color;
+            let nextColor = typeof nextSegment.color === "object" ? rgbToHex(nextSegment.color) : computeCssColor(nextSegment.color);
 
             if (nextColor.includes("var(--") && element) {
               nextColor = getComputedStyle(element).getPropertyValue(nextColor.replace(/(var\()|(\))/g, "").trim());
@@ -211,7 +212,7 @@ export function computeSegments(numberState: number, segments: SegmentsConfig[] 
 
             return interpolateColor(color, nextColor, valueToPercentage(numberState, Number(segment.from), Number(nextSegment.from)));
           } else {
-            const color = typeof segment.color === "object" ? rgbToHex(segment.color) : segment.color;
+            const color = typeof segment.color === "object" ? rgbToHex(segment.color) : computeCssColor(segment.color);
             return color;
           }
       }


### PR DESCRIPTION
This adds automatic color name conversion to theme color used in Home Assistant e.g. `red`->`var(--red-color)`.