### PR TITLE
fix: JavaScript templates causing frontend performance issues

### DIFF
--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -25,7 +25,7 @@ import "../components/mcg-badge-state";
 import "../components/modern-circular-gauge-state";
 import { compareHass } from "../utils/compare-hass";
 import { computeCssColor } from "../ha/common/color/compute-color";
-import HomeAssistantJavaScriptTemplates from "home-assistant-javascript-templates";
+import { getHaJsTemplates } from "../utils/js-templates";
 import { compareTemplateResult } from "../utils/compare-template-result";
 
 const MAX_ANGLE = 270;
@@ -61,7 +61,7 @@ export class ModernCircularGaugeBadge extends LitElement {
 
   private _interval?: any;
 
-  private haJsTemplates = new HomeAssistantJavaScriptTemplates(document.querySelector("home-assistant") as any);
+  private haJsTemplates = getHaJsTemplates();
 
   public static async getStubConfig(hass: HomeAssistant): Promise<ModernCircularGaugeBadgeConfig> {
     const entities = Object.keys(hass.states);

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -26,7 +26,7 @@ import { getTimerRemainingSeconds, getTimestampRemainingSeconds } from "../utils
 import { compareHass } from "../utils/compare-hass";
 import { MCGGraphConfig } from "../components/type";
 import { computeCssColor } from "../ha/common/color/compute-color";
-import HomeAssistantJavaScriptTemplates from "home-assistant-javascript-templates";
+import { getHaJsTemplates } from "../utils/js-templates";
 import { compareTemplateResult } from "../utils/compare-template-result";
 
 registerCustomCard({
@@ -58,7 +58,7 @@ export class ModernCircularGauge extends LitElement {
 
   private _interval?: any;
 
-  private haJsTemplates = new HomeAssistantJavaScriptTemplates(document.querySelector("home-assistant") as any);
+  private haJsTemplates = getHaJsTemplates();
 
   public static async getConfigElement(): Promise<HTMLElement> {
     await import("./mcg-editor");

--- a/src/utils/js-templates.ts
+++ b/src/utils/js-templates.ts
@@ -1,0 +1,16 @@
+import HomeAssistantJavaScriptTemplates from "home-assistant-javascript-templates";
+
+declare global {
+  interface Window {
+    __mcg_haJsTemplates?: HomeAssistantJavaScriptTemplates;
+  }
+}
+
+export const getHaJsTemplates = (): HomeAssistantJavaScriptTemplates => {
+  if (!window.__mcg_haJsTemplates) {
+    window.__mcg_haJsTemplates = new HomeAssistantJavaScriptTemplates(
+      document.querySelector("home-assistant") as any
+    );
+  }
+  return window.__mcg_haJsTemplates;
+};


### PR DESCRIPTION
Version v0.13.0 introduced JavaScript templates and each card or badge was creating its own template rendering engine that subscribed to entity change through websocket. This caused multiple subscriptions to happen, if there was a lot of cards present, that caused very long websocket messages sometimes being over 100000 in length putting heavy load on client device, crashing frontend or throwing errors about websocket queue being too long even thou there are no JavaScript templates in cards config.

This fix makes template rendering engine global for all cards and badges.