### PR TITLE
feat: per entity `smooth_segments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | adaptive_icon_color | `boolean` | `false` | Makes icon color adaptive to current color segment
 | adaptive_state_color | `boolean` | `false` | Makes state color adaptive to current color segment
 | adaptive_label_color | `boolean` | `false` | Makes label color adaptive to current color segment
-| smooth_segments | `boolean` | `false` | Smooth color segments
+| smooth_segments | `boolean` | `false` | Smooth color segments for primary gauge
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | inverted_mode | `boolean` | `false` | Inverts gauge fill logic and ignores start_from_zero, 0 -> full gauge, 100 -> empty gauge
 | state_font_size | `number` | `24` | Initial state size in px
@@ -165,6 +165,7 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | show_unit | `boolean` | `true` | Show secondary unit
 | show_in_graph | `boolean` | `false` | Show secondary entity on the graph
 | adaptive_graph_range | `boolean` | `false` | Adapt y-axis range to min and max value of the entity history
+| smooth_segments | `boolean` | `false` | Smooth color segments for secondary gauge
 | show_seconds | `boolean` | `true` | Show seconds when displaying time based entities
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | inverted_mode | `boolean` | `false` | Inverts gauge fill logic and ignores start_from_zero, 0 -> full gauge, 100 -> empty gauge
@@ -195,6 +196,7 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | show_unit | `boolean` | `true` | Show secondary unit
 | show_in_graph | `boolean` | `false` | Show tertiary entity on the graph
 | adaptive_graph_range | `boolean` | `false` | Adapt y-axis range to min and max value of the entity history
+| smooth_segments | `boolean` | `false` | Smooth color segments for tertiary gauge
 | show_seconds | `boolean` | `true` | Show seconds when displaying time based entities
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | inverted_mode | `boolean` | `false` | Inverts gauge fill logic and ignores start_from_zero, 0 -> full gauge, 100 -> empty gauge

--- a/src/card/mcg-editor.ts
+++ b/src/card/mcg-editor.ts
@@ -125,10 +125,6 @@ export class ModernCircularGaugeEditor extends LitElement {
             type: "grid",
             schema: [
               {
-                name: "smooth_segments",
-                selector: { boolean: {} },
-              },
-              {
                 name: "show_header",
                 default: true,
                 selector: { boolean: {} },

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -100,6 +100,10 @@ export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadi
     type: "grid",
     schema: [
       {
+        name: "smooth_segments",
+        selector: { boolean: {} },
+      },
+      {
         name: "needle",
         disabled: !showGaugeOptions,
         selector: { boolean: {} },

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -703,7 +703,7 @@ export class ModernCircularGauge extends LitElement {
         .radius=${tertiaryObj.gauge_radius ?? (secondaryInner ? TERTIARY_RADIUS : INNER_RADIUS)}
         .gaugeType=${this._config?.gauge_type}
         .segments=${segments}
-        .smoothSegments=${this._config?.smooth_segments}
+        .smoothSegments=${tertiaryObj.smooth_segments}
         .foregroundStyle=${tertiaryObj?.gauge_foreground_style}
         .backgroundStyle=${tertiaryObj?.gauge_background_style}
         .needle=${tertiaryObj?.needle}
@@ -832,7 +832,7 @@ export class ModernCircularGauge extends LitElement {
         .radius=${this._config?.combine_gauges && this._config.gauge_type === "full" ? (this._config?.gauge_radius ?? RADIUS) : (secondaryObj.gauge_radius ?? INNER_RADIUS)}
         .gaugeType=${this._config?.gauge_type}
         .segments=${segments}
-        .smoothSegments=${this._config?.smooth_segments}
+        .smoothSegments=${secondaryObj.smooth_segments}
         .foregroundStyle=${secondaryObj?.gauge_foreground_style}
         .backgroundStyle=${secondaryObj?.gauge_background_style}
         .needle=${secondaryObj?.needle}

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -28,6 +28,7 @@ export interface BaseEntityConfig {
     start_from_zero?: boolean;
     inverted_mode?: boolean;
     gauge_radius?: number;
+    smooth_segments?: boolean;
     gauge_background_style?: GaugeElementConfig;
     gauge_foreground_style?: GaugeElementConfig;
     adaptive_state_color?: boolean;


### PR DESCRIPTION
Makes `smooth_segments` per entity. Might break configuration making secondary and tertiary segments not smooth. Users need to update the card config.