### PR TITLE
feat: entity state formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | show_in_graph | `boolean` | `true` | Show primary entity on the graph
 | adaptive_graph_range | `boolean` | `false` | Adapt y-axis range to min and max value of the entity history
 | show_seconds | `boolean` | `true` | Show seconds when displaying time based entities
+| time_format | `string` | `digital` | Time format: `digital` (00:00), `compact` (1h 15m), or `minutes` (120m)
+| state_format | `string` | `default` | State format: `default`, `wind_direction` (converts degrees to cardinal directions like N, NE, E, etc.), or `percentage` (displays value as percentage of gauge range)
 | needle | `boolean` | `false` | 
 | state_text | `string` | Entity state | Displayed state override. May contain [templates](#templates)|✅
 | adaptive_icon_color | `boolean` | `false` | Makes icon color adaptive to current color segment
@@ -169,6 +171,8 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | adaptive_graph_range | `boolean` | `false` | Adapt y-axis range to min and max value of the entity history
 | smooth_segments | `boolean` | `false` | Smooth color segments for secondary gauge
 | show_seconds | `boolean` | `true` | Show seconds when displaying time based entities
+| time_format | `string` | `digital` | Time format: `digital` (00:00), `compact` (1h 15m), or `minutes` (120m)
+| state_format | `string` | `default` | State format: `default`, `wind_direction` (converts degrees to cardinal directions like N, NE, E, etc.), or `percentage` (displays value as percentage of gauge range)
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | inverted_mode | `boolean` | `false` | Inverts gauge fill logic and ignores start_from_zero, 0 -> full gauge, 100 -> empty gauge
 | state_font_size | `number` | `10` or `24` | State size in px

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | adaptive_graph_range | `boolean` | `false` | Adapt y-axis range to min and max value of the entity history
 | show_seconds | `boolean` | `true` | Show seconds when displaying time based entities
 | time_format | `string` | `digital` | Time format: `digital` (00:00), `compact` (1h 15m), or `minutes` (120m)
-| state_format | `string` | `default` | State format: `default`, `wind_direction` (converts degrees to cardinal directions like N, NE, E, etc.), or `percentage` (displays value as percentage of gauge range)
+| state_format | `string` | `default` | State format: `default`, `direction` (converts degrees to cardinal directions like N, NE, E, etc.), or `percentage` (displays value as percentage of gauge range)
 | needle | `boolean` | `false` | 
 | state_text | `string` | Entity state | Displayed state override. May contain [templates](#templates)|✅
 | adaptive_icon_color | `boolean` | `false` | Makes icon color adaptive to current color segment
@@ -172,7 +172,7 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | smooth_segments | `boolean` | `false` | Smooth color segments for secondary gauge
 | show_seconds | `boolean` | `true` | Show seconds when displaying time based entities
 | time_format | `string` | `digital` | Time format: `digital` (00:00), `compact` (1h 15m), or `minutes` (120m)
-| state_format | `string` | `default` | State format: `default`, `wind_direction` (converts degrees to cardinal directions like N, NE, E, etc.), or `percentage` (displays value as percentage of gauge range)
+| state_format | `string` | `default` | State format: `default`, `direction` (converts degrees to cardinal directions like N, NE, E, etc.), or `percentage` (displays value as percentage of gauge range)
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | inverted_mode | `boolean` | `false` | Inverts gauge fill logic and ignores start_from_zero, 0 -> full gauge, 100 -> empty gauge
 | state_font_size | `number` | `10` or `24` | State size in px

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | show_icon | `bool` | `true` | Show icon
 | show_unit | `bool` | `true` | Show unit
 | show_seconds | `boolean` | `true` | Show seconds when displaying time based entities
+| time_format | `string` | `digital` | Time format: `digital` (00:00), `compact` (1h 15m), or `minutes` (120m)
+| state_format | `string` | `default` | State format: `default`, `direction` (converts degrees to cardinal directions like N, NE, E, etc.), or `percentage` (displays value as percentage of gauge range)
 | needle | `bool` | `false` | 
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | inverted_mode | `boolean` | `false` | Inverts gauge fill logic and ignores start_from_zero, 0 -> full gauge, 100 -> empty gauge
@@ -205,6 +207,8 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | adaptive_graph_range | `boolean` | `false` | Adapt y-axis range to min and max value of the entity history
 | smooth_segments | `boolean` | `false` | Smooth color segments for tertiary gauge
 | show_seconds | `boolean` | `true` | Show seconds when displaying time based entities
+| time_format | `string` | `digital` | Time format: `digital` (00:00), `compact` (1h 15m), or `minutes` (120m)
+| state_format | `string` | `default` | State format: `default`, `direction` (converts degrees to cardinal directions like N, NE, E, etc.), or `percentage` (displays value as percentage of gauge range)
 | start_from_zero | `boolean` | `false` | Start gauge from zero instead of min
 | inverted_mode | `boolean` | `false` | Inverts gauge fill logic and ignores start_from_zero, 0 -> full gauge, 100 -> empty gauge
 | state_font_size | `number` | `10` | State size in px

--- a/src/badge/gauge-badge-config.ts
+++ b/src/badge/gauge-badge-config.ts
@@ -25,5 +25,5 @@ export interface ModernCircularGaugeBadgeConfig extends LovelaceBadgeConfig {
   smooth_segments?: boolean;
   segments?: SegmentsConfig[];
   time_format?: "compact" | "minutes" | "digital";
-  state_format?: "default" | "wind_direction" | "percentage";
+  state_format?: "default" | "direction" | "percentage";
 }

--- a/src/badge/gauge-badge-config.ts
+++ b/src/badge/gauge-badge-config.ts
@@ -24,4 +24,6 @@ export interface ModernCircularGaugeBadgeConfig extends LovelaceBadgeConfig {
   gauge_background_style?: GaugeElementConfig;
   smooth_segments?: boolean;
   segments?: SegmentsConfig[];
+  time_format?: "compact" | "minutes" | "digital";
+  state_format?: "default" | "wind_direction" | "percentage";
 }

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -145,6 +145,7 @@ export class ModernCircularGaugeBadgeEditor extends LitElement {
                     { value: "minutes", label: "Minutes (120m)" },
                   ],
                   mode: "dropdown",
+                  translation_key: "time_format_options",
                 }},
               },
               {
@@ -156,6 +157,7 @@ export class ModernCircularGaugeBadgeEditor extends LitElement {
                     { value: "percentage", label: "Percentage" },
                   ],
                   mode: "dropdown",
+                  translation_key: "state_format_options",
                 }},
               },
               {

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -137,6 +137,28 @@ export class ModernCircularGaugeBadgeEditor extends LitElement {
                 selector: { number: { step: 1, min: 0 } },
               },
               {
+                name: "time_format",
+                selector: { select: {
+                  options: [
+                    { value: "digital", label: "Digital (00:00)" },
+                    { value: "compact", label: "Compact (1h 15m)" },
+                    { value: "minutes", label: "Minutes (120m)" },
+                  ],
+                  mode: "dropdown",
+                }},
+              },
+              {
+                name: "state_format",
+                selector: { select: {
+                  options: [
+                    { value: "default", label: "Default" },
+                    { value: "wind_direction", label: "Wind Direction" },
+                    { value: "percentage", label: "Percentage" },
+                  ],
+                  mode: "dropdown",
+                }},
+              },
+              {
                 name: "inverted_mode",
                 default: false,
                 selector: { boolean: {} },

--- a/src/badge/gauge-badge-editor.ts
+++ b/src/badge/gauge-badge-editor.ts
@@ -152,7 +152,7 @@ export class ModernCircularGaugeBadgeEditor extends LitElement {
                 selector: { select: {
                   options: [
                     { value: "default", label: "Default" },
-                    { value: "wind_direction", label: "Wind Direction" },
+                    { value: "direction", label: "Direction" },
                     { value: "percentage", label: "Percentage" },
                   ],
                   mode: "dropdown",

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -413,6 +413,9 @@ export class ModernCircularGaugeBadge extends LitElement {
         .stateOverride=${stateOverride ?? templatedState}
         .showSeconds=${this._config.show_seconds}
         .decimals=${this._config.decimals}
+        .min=${min}
+        .max=${max}
+        .stateFormat=${this._config.state_format}
       ></mcg-badge-state>
     `;
 
@@ -499,6 +502,8 @@ export class ModernCircularGaugeBadge extends LitElement {
               .stateOverride=${stateOverride ?? templatedState}
               .showSeconds=${this._config.show_seconds}
               .decimals=${this._config.decimals}
+              .timeFormat=${this._config.time_format}
+              .stateFormat=${this._config.state_format}
             ></modern-circular-gauge-state>
           ` : nothing}
       </div>

--- a/src/badge/gauge-badge.ts
+++ b/src/badge/gauge-badge.ts
@@ -397,7 +397,7 @@ export class ModernCircularGaugeBadge extends LitElement {
     const current = this._config.needle ? undefined : currentDashArc(numberState, min, max, RADIUS, this._config.start_from_zero, undefined, undefined, undefined, this._config.inverted_mode);
 
     const stateOverride = this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : (this._config.state_text || undefined));
-    const unit = this._config.show_unit ?? true ? (this._config.unit ?? stateObj?.attributes.unit_of_measurement) || "" : "";
+    const unit = this._config.unit;
     
     const showIcon = this._config.show_icon ?? true;
 
@@ -416,6 +416,8 @@ export class ModernCircularGaugeBadge extends LitElement {
         .min=${min}
         .max=${max}
         .stateFormat=${this._config.state_format}
+        .timeFormat=${this._config.time_format}
+        .showUnit=${this._config.show_unit ?? true}
       ></mcg-badge-state>
     `;
 
@@ -504,6 +506,7 @@ export class ModernCircularGaugeBadge extends LitElement {
               .decimals=${this._config.decimals}
               .timeFormat=${this._config.time_format}
               .stateFormat=${this._config.state_format}
+              .showUnit=${this._config.show_unit ?? true}
             ></modern-circular-gauge-state>
           ` : nothing}
       </div>

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -158,6 +158,7 @@ export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadi
             { value: "minutes", label: "Minutes (120m)" },
           ],
           mode: "dropdown",
+          translation_key: "time_format_options",
         }},
       },
       {
@@ -169,6 +170,7 @@ export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadi
             { value: "percentage", label: "Percentage" },
           ],
           mode: "dropdown",
+          translation_key: "state_format_options",
         }},
       },
       {

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -150,6 +150,28 @@ export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadi
         selector: { number: { step: 1, min: 0 } },
       },
       {
+        name: "time_format",
+        selector: { select: {
+          options: [
+            { value: "digital", label: "Digital (00:00)" },
+            { value: "compact", label: "Compact (1h 15m)" },
+            { value: "minutes", label: "Minutes (120m)" },
+          ],
+          mode: "dropdown",
+        }},
+      },
+      {
+        name: "state_format",
+        selector: { select: {
+          options: [
+            { value: "default", label: "Default" },
+            { value: "wind_direction", label: "Wind Direction" },
+            { value: "percentage", label: "Percentage" },
+          ],
+          mode: "dropdown",
+        }},
+      },
+      {
         name: "inverted_mode",
         default: false,
         selector: { boolean: {} },

--- a/src/card/mcg-schema.ts
+++ b/src/card/mcg-schema.ts
@@ -165,7 +165,7 @@ export const getEntityStyleSchema = (showGaugeOptions: boolean, gaugeDefaultRadi
         selector: { select: {
           options: [
             { value: "default", label: "Default" },
-            { value: "wind_direction", label: "Wind Direction" },
+            { value: "direction", label: "Direction" },
             { value: "percentage", label: "Percentage" },
           ],
           mode: "dropdown",

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -425,6 +425,10 @@ export class ModernCircularGauge extends LitElement {
             .showSeconds=${this._config.show_seconds}
             .decimals=${this._config.decimals}
             .unitSuperscript=${this._config.unit_superscript}
+            .timeFormat=${this._config.time_format}
+            .stateFormat=${this._config.state_format}
+            .min=${min}
+            .max=${max}
           ></modern-circular-gauge-state>
           ` : nothing}
           ${this._renderSecondaryState()}
@@ -984,6 +988,10 @@ export class ModernCircularGauge extends LitElement {
       .showSeconds=${secondary.show_seconds}
       .decimals=${secondary.decimals}
       .unitSuperscript=${secondary.unit_superscript}
+      .timeFormat=${secondary.time_format}
+      .stateFormat=${secondary.state_format}
+      .min=${Number(this._templateResults?.secondaryMin?.result ?? secondary.min) || DEFAULT_MIN}
+      .max=${Number(this._templateResults?.secondaryMax?.result ?? secondary.max) || DEFAULT_MAX}
     ></modern-circular-gauge-state>
     `;
   }
@@ -1028,6 +1036,9 @@ export class ModernCircularGauge extends LitElement {
         .showSeconds=${this._config.show_seconds}
         .decimals=${this._config.decimals}
         .unitSuperscript=${this._config.unit_superscript}
+        .timeFormat=${this._config.time_format}
+        .min=${Number(this._templateResults?.min?.result ?? this._config.min) || DEFAULT_MIN}
+        .max=${Number(this._templateResults?.max?.result ?? this._config.max) || DEFAULT_MAX}
         small
       ></modern-circular-gauge-state>
       `;
@@ -1122,6 +1133,10 @@ export class ModernCircularGauge extends LitElement {
       .showSeconds=${tertiary.show_seconds}
       .decimals=${tertiary.decimals}
       .unitSuperscript=${tertiary.unit_superscript}
+      .timeFormat=${tertiary.time_format}
+      .stateFormat=${tertiary.state_format}
+      .min=${Number(this._templateResults?.tertiaryMin?.result ?? tertiary.min) || DEFAULT_MIN}
+      .max=${Number(this._templateResults?.tertiaryMax?.result ?? tertiary.max) || DEFAULT_MAX}
       small
     ></modern-circular-gauge-state>
     `;

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -324,7 +324,7 @@ export class ModernCircularGauge extends LitElement {
 
     const attributes = stateObj?.attributes ?? undefined;
 
-    const unit = this._config.unit ?? stateObj?.attributes?.unit_of_measurement ?? "";
+    const unit = this._config.unit;
 
     const min = Number(this._templateResults?.min?.result ?? this._config.min) || DEFAULT_MIN;
     const max = Number(this._templateResults?.max?.result ?? this._config.max ?? calculatedMax) || DEFAULT_MAX;
@@ -943,7 +943,7 @@ export class ModernCircularGauge extends LitElement {
 
     const attributes = stateObj?.attributes ?? undefined;
 
-    const unit = secondary.unit ?? attributes?.unit_of_measurement;
+    const unit = secondary.unit;
 
     const state = Number(templatedState ?? attributes[secondary.attribute!] ?? stateObj.state);
     const stateOverride = this._templateResults?.secondaryStateText?.result ?? (isTemplate(String(secondary.state_text)) ? "" : (secondary.state_text || undefined));
@@ -1009,7 +1009,7 @@ export class ModernCircularGauge extends LitElement {
       const templatedState = this._templateResults?.entity?.result;
       const stateObj = this._getEntityStateObj("primary");
       const numberState = Number(this._getEntityState("primary", this._config.attribute));
-      const unit = this._config.unit ?? stateObj?.attributes?.unit_of_measurement ?? "";
+      const unit = this._config.unit;
 
       const stateOverride = this._templateResults?.stateText?.result ?? (isTemplate(String(this._config.state_text)) ? "" : (this._config.state_text || undefined));
       const segments = (this._templateResults?.segments?.result as unknown) as SegmentsConfig[] ?? this._config.segments;
@@ -1091,7 +1091,7 @@ export class ModernCircularGauge extends LitElement {
     }
 
     const attributes = stateObj?.attributes ?? undefined;
-    const unit = tertiary.unit ?? attributes?.unit_of_measurement;
+    const unit = tertiary.unit;
     const state = Number(templatedState ?? attributes[tertiary.attribute!] ?? stateObj.state);
     const stateOverride = this._templateResults?.tertiaryStateText?.result ?? (isTemplate(String(tertiary.state_text)) ? "" : (tertiary.state_text || undefined));
     const segments = (this._templateResults?.tertiarySegments?.result as unknown) as SegmentsConfig[] ?? tertiary.segments;

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -35,6 +35,8 @@ export interface BaseEntityConfig {
     adaptive_state_color?: boolean;
     adaptive_label_color?: boolean;
     segments?: SegmentsConfig[];
+    time_format?: "compact" | "minutes" | "digital";
+    state_format?: "default" | "wind_direction" | "percentage";
 }
 
 export interface SecondaryEntity extends BaseEntityConfig {
@@ -108,4 +110,6 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     secondary?: SecondaryEntity | string;
     tertiary?: TertiaryEntity | string;
     secondary_entity?: SecondaryEntity; // Unused
+    time_format?: "compact" | "minutes" | "digital";
+    state_format?: "default" | "wind_direction" | "percentage";
 }

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -36,7 +36,7 @@ export interface BaseEntityConfig {
     adaptive_label_color?: boolean;
     segments?: SegmentsConfig[];
     time_format?: "compact" | "minutes" | "digital";
-    state_format?: "default" | "wind_direction" | "percentage";
+    state_format?: "default" | "direction" | "percentage";
 }
 
 export interface SecondaryEntity extends BaseEntityConfig {
@@ -111,5 +111,5 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     tertiary?: TertiaryEntity | string;
     secondary_entity?: SecondaryEntity; // Unused
     time_format?: "compact" | "minutes" | "digital";
-    state_format?: "default" | "wind_direction" | "percentage";
+    state_format?: "default" | "direction" | "percentage";
 }

--- a/src/components/mcg-badge-state.ts
+++ b/src/components/mcg-badge-state.ts
@@ -2,8 +2,6 @@ import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { HomeAssistant } from "../ha/types";
 import { HassEntity } from "home-assistant-js-websocket";
-import { TIMESTAMP_STATE_DOMAINS } from "../const";
-import { computeStateDomain } from "../ha/common/entity/compute_state_domain";
 import { computeState } from "../utils/compute-state";
 
 @customElement("mcg-badge-state")
@@ -24,6 +22,12 @@ export class McgBadgeState extends LitElement {
 
   @property({ type: Boolean }) public showSeconds = true;
 
+  @property() public stateFormat?: "default" | "wind_direction" | "percentage";
+
+  @property({ type: Number }) public min?: number;
+
+  @property({ type: Number }) public max?: number;
+
   connectedCallback(): void {
     super.connectedCallback();
   }
@@ -33,7 +37,15 @@ export class McgBadgeState extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const state = computeState(this.hass!, this.stateObj!, this.entityAttribute!, this.stateOverride!, this.decimals, this.showSeconds);
+    const state = computeState(this.hass!, this.stateObj, {
+      entityAttribute: this.entityAttribute,
+      stateOverride: this.stateOverride || undefined,
+      decimals: this.decimals,
+      showSeconds: this.showSeconds,
+      stateFormat: this.stateFormat,
+      min: this.min,
+      max: this.max
+    });
 
     return html`
       ${state} ${this.unit}

--- a/src/components/mcg-badge-state.ts
+++ b/src/components/mcg-badge-state.ts
@@ -22,7 +22,7 @@ export class McgBadgeState extends LitElement {
 
   @property({ type: Boolean }) public showSeconds = true;
 
-  @property() public stateFormat?: "default" | "wind_direction" | "percentage";
+  @property() public stateFormat?: "default" | "direction" | "percentage";
 
   @property({ type: Number }) public min?: number;
 

--- a/src/components/mcg-badge-state.ts
+++ b/src/components/mcg-badge-state.ts
@@ -3,6 +3,7 @@ import { customElement, property } from "lit/decorators.js";
 import { HomeAssistant } from "../ha/types";
 import { HassEntity } from "home-assistant-js-websocket";
 import { computeState } from "../utils/compute-state";
+import { processEntityState } from "../utils/entity-state-processor";
 
 @customElement("mcg-badge-state")
 export class McgBadgeState extends LitElement {
@@ -22,6 +23,8 @@ export class McgBadgeState extends LitElement {
 
   @property({ type: Boolean }) public showSeconds = true;
 
+  @property() public timeFormat?: "compact" | "minutes" | "digital";
+
   @property() public stateFormat?: "default" | "direction" | "percentage";
 
   @property({ type: Number }) public min?: number;
@@ -37,18 +40,26 @@ export class McgBadgeState extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const state = computeState(this.hass!, this.stateObj, {
+    if (!this.hass || (!this.stateObj && this.stateOverride === undefined)) {
+      return html``;
+    }
+
+    const processedState = processEntityState(this.hass, this.stateObj, {
       entityAttribute: this.entityAttribute,
       stateOverride: this.stateOverride || undefined,
       decimals: this.decimals,
       showSeconds: this.showSeconds,
+      timeFormat: this.timeFormat,
       stateFormat: this.stateFormat,
       min: this.min,
       max: this.max
     });
 
+    const state = processedState.displayState;
+    const unit = this.showUnit ? this.unit ?? processedState.unit ?? this.stateObj?.attributes.unit_of_measurement ?? "" : "";
+
     return html`
-      ${state} ${this.unit}
+      ${state} ${unit}
     `;
   }
 }

--- a/src/components/modern-circular-gauge-state.ts
+++ b/src/components/modern-circular-gauge-state.ts
@@ -41,6 +41,14 @@ export class ModernCircularGaugeState extends LitElement {
 
   @property({ type: Boolean }) public showSeconds = true;
 
+  @property() public timeFormat?: "compact" | "minutes" | "digital";
+
+  @property() public stateFormat?: "default" | "wind_direction" | "percentage";
+
+  @property({ type: Number }) public min?: number;
+
+  @property({ type: Number }) public max?: number;
+
   @state() private _updated = false;
 
   connectedCallback(): void {
@@ -90,7 +98,16 @@ export class ModernCircularGaugeState extends LitElement {
       return html``;
     }
 
-    const state = computeState(this.hass, this.stateObj!, this.entityAttribute!, this.stateOverride!, this.decimals, this.showSeconds);
+    const state = computeState(this.hass, this.stateObj, {
+      entityAttribute: this.entityAttribute,
+      stateOverride: this.stateOverride || undefined,
+      decimals: this.decimals,
+      showSeconds: this.showSeconds,
+      timeFormat: this.timeFormat,
+      stateFormat: this.stateFormat,
+      min: this.min,
+      max: this.max
+    });
     const verticalOffset = this.verticalOffset ?? 0;
 
     return html`

--- a/src/components/modern-circular-gauge-state.ts
+++ b/src/components/modern-circular-gauge-state.ts
@@ -6,6 +6,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { GaugeType } from "../card/type";
 import { computeState } from "../utils/compute-state";
+import { processEntityState } from "../utils/entity-state-processor";
 
 @customElement("modern-circular-gauge-state")
 export class ModernCircularGaugeState extends LitElement {
@@ -98,7 +99,7 @@ export class ModernCircularGaugeState extends LitElement {
       return html``;
     }
 
-    const state = computeState(this.hass, this.stateObj, {
+    const processedState = processEntityState(this.hass, this.stateObj, {
       entityAttribute: this.entityAttribute,
       stateOverride: this.stateOverride || undefined,
       decimals: this.decimals,
@@ -108,14 +109,18 @@ export class ModernCircularGaugeState extends LitElement {
       min: this.min,
       max: this.max
     });
+
+    const state = processedState.displayState;
+    const unit = this.unit ?? processedState.unit ?? this.stateObj?.attributes.unit_of_measurement ?? "";
+
     const verticalOffset = this.verticalOffset ?? 0;
 
     return html`
     <svg class="state ${classMap({ "small": this.small })}" overflow="visible" viewBox="${-50 + (this.horizontalOffset ?? 0)} -50 100 ${this.gaugeType == "half" ? 50 : 100}">
       <text x="0" y=${verticalOffset} class="value">
         ${state}
-        ${this.showUnit ? !(this.unitSuperscript ?? !this.small) ? this.unit : svg`
-        <tspan class="unit" dx=${this.small ? "-2" : "-4"} dy=${this.small ? "-0.3em" : "-0.8em"}>${this.unit}</tspan>
+        ${this.showUnit ? !(this.unitSuperscript ?? !this.small) ? unit : svg`
+        <tspan class="unit" dx=${this.small ? "-2" : "-4"} dy=${this.small ? "-0.3em" : "-0.8em"}>${unit}</tspan>
         ` : nothing}
       </text>
       <text class="state-label" style=${styleMap({ "font-size": this.labelFontSize ? `${this.labelFontSize}px` : undefined })} y=${verticalOffset + (this.small ? (9 * Math.sign(verticalOffset)) : 13)}>

--- a/src/components/modern-circular-gauge-state.ts
+++ b/src/components/modern-circular-gauge-state.ts
@@ -43,7 +43,7 @@ export class ModernCircularGaugeState extends LitElement {
 
   @property() public timeFormat?: "compact" | "minutes" | "digital";
 
-  @property() public stateFormat?: "default" | "wind_direction" | "percentage";
+  @property() public stateFormat?: "default" | "direction" | "percentage";
 
   @property({ type: Number }) public min?: number;
 

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -94,7 +94,7 @@
       }
     }
   },
-  "wind_direction": {
+  "direction": {
     "N": "N",
     "NNE": "NNE",
     "NE": "NE",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -93,5 +93,23 @@
         "full": "Full"
       }
     }
+  },
+  "wind_direction": {
+    "N": "N",
+    "NNE": "NNE",
+    "NE": "NE",
+    "ENE": "ENE",
+    "E": "E",
+    "ESE": "ESE",
+    "SE": "SE",
+    "SSE": "SSE",
+    "S": "S",
+    "SSW": "SSW",
+    "SW": "SW",
+    "WSW": "WSW",
+    "W": "W",
+    "WNW": "WNW",
+    "NW": "NW",
+    "NNW": "NNW"
   }
 }

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -47,6 +47,8 @@
     "graph_points_per_hour": "Points per hour",
     "inverted_mode": "Inverted mode",
     "unit_superscript": "Unit superscript",
+    "time_format": "Time format",
+    "state_format": "State format",
     "helper": {
       "start_from_zero": "Gauge starts from zero instead of min",
       "primary_label": "Text displayed under the main state when secondary state size is set to big",
@@ -91,6 +93,20 @@
         "standard": "Standard",
         "half": "Half",
         "full": "Full"
+      }
+    },
+    "time_format_options": {
+      "options": {
+        "digital": "Digital (00:00)",
+        "compact": "Compact (0h 0m)",
+        "minutes": "Minutes (120m)"
+      }
+    },
+    "state_format_options": {
+      "options": {
+        "default": "Default",
+        "direction": "Direction",
+        "percentage": "Percentage"
       }
     }
   },

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -93,5 +93,23 @@
         "full": "Pełny"
       }
     }
+  },
+  "wind_direction": {
+    "N": "Pn.",
+    "NNE": "Pn. Pn. Wsch.",
+    "NE": "Pn. Wsch.",
+    "ENE": "Wsch. Pn. Wsch.",
+    "E": "Wsch.",
+    "ESE": "Wsch. Pd. Wsch.",
+    "SE": "Pd. Wsch.",
+    "SSE": "Pd. Pd. Wsch.",
+    "S": "Pd.",
+    "SSW": "Pd. Pd. Zach.",
+    "SW": "Pd. Zach.",
+    "WSW": "Zach. Pd. Zach.",
+    "W": "Zach.",
+    "WNW": "Zach. Pn. Zach.",
+    "NW": "Pn. Zach.",
+    "NNW": "Pn. Pn. Zach."
   }
 }

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -47,6 +47,8 @@
     "graph_points_per_hour": "Punkty na godzinę",
     "inverted_mode": "Tryb odwrócony",
     "unit_superscript": "Jednostka jako indeks górny",
+    "time_format": "Format czasu",
+    "state_format": "Format stanu",
     "helper": {
       "start_from_zero": "Wskaźnik rozpoczyna się od zera zamiast od minimum",
       "primary_label": "Tekst wyświetlony pod głównym stanem, gdy rozmiar stanu informacji drugorzędnej jest duży",
@@ -91,6 +93,20 @@
         "standard": "Standard",
         "half": "Połówka",
         "full": "Pełny"
+      }
+    },
+    "time_format_options": {
+      "options": {
+        "digital": "Cyfrowy (00:00)",
+        "compact": "Kompaktowy (0h 0m)",
+        "minutes": "Minuty (120m)"
+      }
+    },
+    "state_format_options": {
+      "options": {
+        "default": "Domyślny",
+        "direction": "Kierunek",
+        "percentage": "Procent"
       }
     }
   },

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -94,7 +94,7 @@
       }
     }
   },
-  "wind_direction": {
+  "direction": {
     "N": "Pn.",
     "NNE": "Pn. Pn. Wsch.",
     "NE": "Pn. Wsch.",

--- a/src/utils/compute-state.ts
+++ b/src/utils/compute-state.ts
@@ -1,61 +1,11 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { TIMESTAMP_STATE_DOMAINS } from "../const";
-import { computeStateDomain } from "../ha/common/entity/compute_state_domain";
-import { formatNumber, getNumberFormatOptions, getDefaultFormatOptions } from "./format_number";
-import secondsToDuration from "./seconds_to_duration";
 import { HomeAssistant } from "../ha/types";
+import { processEntityState, EntityStateProcessorOptions } from "./entity-state-processor";
 
-export function computeState(hass: HomeAssistant, stateObj: HassEntity, entityAttribute: string, stateOverride: string, decimals: number | undefined, showSeconds: boolean | undefined): string {
-  if (!stateObj && stateOverride !== undefined) {
-    if (!Number.isNaN(Number(stateOverride))) {
-      const formatOptions = getDefaultFormatOptions(stateOverride, { maximumFractionDigits: decimals, minimumFractionDigits: decimals });
-      return formatNumber(stateOverride, hass?.locale, formatOptions);
-    }
-    return stateOverride;
-  }
-
-  if (stateObj) {
-    const domain = computeStateDomain(stateObj);
-    const deviceClass = stateObj.attributes?.device_class;
-    let secondsUntil: number | undefined;
-
-    if (stateOverride !== undefined && (deviceClass === "timestamp" ||
-      TIMESTAMP_STATE_DOMAINS.includes(domain) || domain === "timer")) {
-      if (!Number.isNaN(Number(stateOverride))) {
-        const formatOptions = getDefaultFormatOptions(stateOverride, { maximumFractionDigits: decimals, minimumFractionDigits: decimals });
-        return formatNumber(stateOverride, hass?.locale, formatOptions);
-      }
-      return stateOverride;
-    }
-
-    if (deviceClass === "timestamp" ||
-      TIMESTAMP_STATE_DOMAINS.includes(domain)
-    ) {
-      const timestamp = new Date(stateObj.state);
-      secondsUntil = Math.round(Math.abs(timestamp.getTime() - Date.now()) / 1000);
-      return secondsToDuration(secondsUntil, showSeconds ?? true) || "0";
-    }
-
-    if (domain === "timer") {
-      secondsUntil = 0;
-      if (stateObj.state === "active") {
-        const timestamp = new Date(stateObj.attributes?.finishes_at);
-        secondsUntil = Math.round(Math.abs(timestamp.getTime() - Date.now()) / 1000);
-        return secondsToDuration(secondsUntil, showSeconds ?? true) || "0";
-      }
-    }
-
-    const state = stateOverride ?? stateObj.attributes[entityAttribute!] ?? stateObj.state;
-    const attributes = stateObj.attributes ?? undefined;
-    const formatOptions = { ...getNumberFormatOptions({ state, attributes } as HassEntity, hass?.entities[stateObj?.entity_id]) };
-    if (decimals !== undefined) {
-      formatOptions.maximumFractionDigits = decimals;
-      formatOptions.minimumFractionDigits = decimals;
-    }
-    const entityState = Number.isNaN(state) ? state
-      : formatNumber(state, hass?.locale, formatOptions);
-    return entityState;
-  }
-
-  return "";
+export function computeState(
+  hass: HomeAssistant,
+  stateObj: HassEntity | undefined,
+  options: EntityStateProcessorOptions = {}
+): string {
+  return processEntityState(hass, stateObj, options).displayState;
 }

--- a/src/utils/entity-state-processor.ts
+++ b/src/utils/entity-state-processor.ts
@@ -1,0 +1,259 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { DEFAULT_MAX, DEFAULT_MIN, TIMESTAMP_STATE_DOMAINS } from "../const";
+import { computeStateDomain } from "../ha/common/entity/compute_state_domain";
+import { formatNumber, getNumberFormatOptions, getDefaultFormatOptions } from "./format_number";
+import secondsToDuration from "./seconds_to_duration";
+import { getTimerRemainingSeconds, getTimestampRemainingSeconds } from "./timer_timestamp_utils";
+import { HomeAssistant } from "../ha/types";
+import localize from "../localize/localize";
+import { valueToPercentageUnclamped } from "./gauge";
+
+export interface EntityStateProcessorOptions {
+  entityAttribute?: string;
+  stateOverride?: string;
+  decimals?: number;
+  showSeconds?: boolean;
+  min?: number;
+  max?: number;
+  timeFormat?: "compact" | "minutes" | "digital";
+  stateFormat?: "default" | "wind_direction" | "percentage";
+}
+
+export interface ProcessedEntityState {
+  displayState: string;
+  numericValue?: number;
+  percentage?: string;
+  isTimerOrTimestamp?: boolean;
+}
+
+const CARDINAL_DIRECTIONS = [
+  "N",
+  "NNE",
+  "NE",
+  "ENE",
+  "E",
+  "ESE",
+  "SE",
+  "SSE",
+  "S",
+  "SSW",
+  "SW",
+  "WSW",
+  "W",
+  "WNW",
+  "NW",
+  "NNW",
+];
+
+const parseNumericValue = (value: unknown): number | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const numeric = Number(value);
+  return Number.isNaN(numeric) ? undefined : numeric;
+};
+
+export function getWindDirectionCardinal(hass: HomeAssistant, value: string | number | undefined): string | undefined {
+  const numeric = parseNumericValue(value);
+  if (numeric === undefined) {
+    return undefined;
+  }
+  const normalized = ((numeric % 360) + 360) % 360;
+  const index = Math.floor((normalized + 11.25) / 22.5) % CARDINAL_DIRECTIONS.length;
+  const directionKey = CARDINAL_DIRECTIONS[index];
+  const translated = localize(hass, `wind_direction.${directionKey}`);
+  return translated === `wind_direction.${directionKey}` ? directionKey : translated;
+}
+
+export function isTimerOrTimestampEntity(stateObj?: HassEntity): boolean {
+  if (!stateObj) {
+    return false;
+  }
+  const domain = computeStateDomain(stateObj);
+  return (
+    stateObj.attributes?.device_class === "timestamp" ||
+    TIMESTAMP_STATE_DOMAINS.includes(domain) ||
+    domain === "timer"
+  );
+}
+
+export function formatPercentage(value: number, min = DEFAULT_MIN, max = DEFAULT_MAX, decimals = 0): string {
+  if (max === min) {
+    return "0";
+  }
+  const percent = valueToPercentageUnclamped(value, min, max) * 100;
+  const rounded = Number.isFinite(percent)
+    ? Number(percent.toFixed(decimals))
+    : 0;
+  const clamped = Math.max(0, Math.min(100, rounded));
+  return `${clamped}`;
+}
+
+export function formatTimerOrTimestampState(
+  stateObj: HassEntity,
+  showSeconds = true,
+  timeFormat: "compact" | "minutes" | "digital" = "digital"
+): { displayState: string; numericValue: number } {
+  const domain = computeStateDomain(stateObj);
+  const seconds =
+    domain === "timer"
+      ? getTimerRemainingSeconds(stateObj)
+      : getTimestampRemainingSeconds(stateObj);
+
+  const displayState = domain === "timer" ? stateObj.state !== "idle" ? formatDuration(seconds, showSeconds, timeFormat) : "idle" : formatDuration(seconds, showSeconds, timeFormat);
+  return {
+    displayState,
+    numericValue: seconds,
+  };
+}
+
+export function formatDuration(
+  seconds: number,
+  showSeconds = true,
+  format: "compact" | "minutes" | "digital" = "digital"
+): string {
+  if (seconds <= 0) {
+    return format === "digital" ? "00:00" : "0s";
+  }
+
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+
+  switch (format) {
+    case "compact":
+      if (hours > 0) {
+        return `${hours}h ${minutes}m${showSeconds ? ` ${secs}s` : ""}`;
+      } else if (minutes > 0) {
+        return `${minutes}m ${showSeconds ? `${secs}s` : ""}`.trim();
+      } else {
+        return showSeconds ? `${secs}s` : "0m";
+      }
+
+    case "minutes":
+      const totalMinutes = Math.floor(seconds / 60);
+      return `${totalMinutes}m`;
+
+    case "digital":
+    default:
+      return secondsToDuration(seconds, showSeconds) || "00:00";
+  }
+}
+
+export function processEntityState(
+  hass: HomeAssistant,
+  stateObj?: HassEntity,
+  options: EntityStateProcessorOptions = {}
+): ProcessedEntityState {
+  const {
+    entityAttribute,
+    stateOverride,
+    decimals,
+    showSeconds,
+    min,
+    max,
+    timeFormat,
+    stateFormat,
+  } = options;
+
+  const numericOverride = parseNumericValue(stateOverride);
+
+  if (!stateObj) {
+    if (stateOverride !== undefined) {
+      if (numericOverride !== undefined) {
+        const formatOptions = getDefaultFormatOptions(stateOverride, {
+          maximumFractionDigits: decimals,
+          minimumFractionDigits: decimals,
+        });
+        const displayState = formatNumber(stateOverride, hass?.locale, formatOptions);
+        return {
+          displayState,
+          numericValue: numericOverride,
+        };
+      }
+      return { displayState: stateOverride };
+    }
+    return { displayState: "" };
+  }
+
+  const isTimerOrTimestamp = isTimerOrTimestampEntity(stateObj);
+  if (stateOverride !== undefined && isTimerOrTimestamp) {
+    if (numericOverride !== undefined) {
+      const formatOptions = getDefaultFormatOptions(stateOverride, {
+        maximumFractionDigits: decimals,
+        minimumFractionDigits: decimals,
+      });
+      const displayState = formatNumber(stateOverride, hass?.locale, formatOptions);
+      return {
+        displayState,
+        numericValue: numericOverride,
+      };
+    }
+    return { displayState: stateOverride };
+  }
+
+  if (isTimerOrTimestamp) {
+    const { displayState, numericValue } = formatTimerOrTimestampState(
+      stateObj,
+      showSeconds ?? true,
+      timeFormat ?? "digital"
+    );
+    if (displayState === "idle") {
+      return { displayState: hass.localize("component.timer.entity_component._.state.idle") };
+    }
+    if (stateObj.state === "paused") {
+      return { displayState: `${displayState} (${hass.localize("component.timer.entity_component._.state.paused")})` };
+    }
+    return {
+      displayState: displayState,
+      numericValue,
+      isTimerOrTimestamp: true,
+    };
+  }
+
+  const rawState =
+    stateOverride ??
+    (entityAttribute ? stateObj.attributes?.[entityAttribute] : undefined) ??
+    stateObj.state;
+  const numericValue = parseNumericValue(rawState);
+
+  if (stateFormat === "wind_direction") {
+    const cardinal = getWindDirectionCardinal(hass, rawState);
+    const displayState = cardinal ?? String(rawState);
+    return {
+      displayState,
+      numericValue,
+    };
+  }
+
+  if (stateFormat === "percentage" && numericValue !== undefined && min !== undefined && max !== undefined) {
+    const percentage = formatPercentage(numericValue, min, max, decimals ?? 0);
+    return {
+      displayState: percentage,
+      numericValue,
+      percentage,
+    };
+  }
+
+  if (numericValue !== undefined) {
+    const formatOptions = {
+      ...getNumberFormatOptions(
+        { state: rawState, attributes: stateObj.attributes } as HassEntity,
+        hass?.entities[stateObj.entity_id]
+      ),
+    };
+    if (decimals !== undefined) {
+      formatOptions.maximumFractionDigits = decimals;
+      formatOptions.minimumFractionDigits = decimals;
+    }
+
+    const displayState = formatNumber(rawState, hass?.locale, formatOptions);
+
+    return {
+      displayState,
+      numericValue,
+    };
+  }
+
+  return { displayState: String(rawState) };
+}

--- a/src/utils/entity-state-processor.ts
+++ b/src/utils/entity-state-processor.ts
@@ -16,7 +16,7 @@ export interface EntityStateProcessorOptions {
   min?: number;
   max?: number;
   timeFormat?: "compact" | "minutes" | "digital";
-  stateFormat?: "default" | "wind_direction" | "percentage";
+  stateFormat?: "default" | "direction" | "percentage";
 }
 
 export interface ProcessedEntityState {
@@ -61,8 +61,8 @@ export function getWindDirectionCardinal(hass: HomeAssistant, value: string | nu
   const normalized = ((numeric % 360) + 360) % 360;
   const index = Math.floor((normalized + 11.25) / 22.5) % CARDINAL_DIRECTIONS.length;
   const directionKey = CARDINAL_DIRECTIONS[index];
-  const translated = localize(hass, `wind_direction.${directionKey}`);
-  return translated === `wind_direction.${directionKey}` ? directionKey : translated;
+  const translated = localize(hass, `direction.${directionKey}`);
+  return translated === `direction.${directionKey}` ? directionKey : translated;
 }
 
 export function isTimerOrTimestampEntity(stateObj?: HassEntity): boolean {
@@ -217,7 +217,7 @@ export function processEntityState(
     stateObj.state;
   const numericValue = parseNumericValue(rawState);
 
-  if (stateFormat === "wind_direction") {
+  if (stateFormat === "direction") {
     const cardinal = getWindDirectionCardinal(hass, rawState);
     const displayState = cardinal ?? String(rawState);
     return {

--- a/src/utils/entity-state-processor.ts
+++ b/src/utils/entity-state-processor.ts
@@ -22,6 +22,7 @@ export interface EntityStateProcessorOptions {
 export interface ProcessedEntityState {
   displayState: string;
   numericValue?: number;
+  unit?: string;
   percentage?: string;
   isTimerOrTimestamp?: boolean;
 }
@@ -223,6 +224,7 @@ export function processEntityState(
     return {
       displayState,
       numericValue,
+      unit: ""
     };
   }
 
@@ -232,6 +234,7 @@ export function processEntityState(
       displayState: percentage,
       numericValue,
       percentage,
+      unit: "%"
     };
   }
 


### PR DESCRIPTION
Adds state formatting config `state_format` with three options:
- default - does not perform additional formatting
- direction - formats degrees to cardinal directions
- percentage - displays entity state as percentage value based on the set min and max values

Additionally introduces `time_format` for timer and timestamp entities and changes how state is formatted when timer is either idle or paused.
`time_format` have also three options:
- digital - 00:00
- compact - 1h 15m
- minutes - 120m