### PR TITLE
feat: opt-in header_wrap for multi-line gauge headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Both [Jinja](#jinja-templates) and [JavaScript](#javascript-templates) templates
 | state_font_family | `string` | Optional | State font family
 | header_font_size | `number` | `14` | Gauge header font size in px
 | header_offset | `number` | `0` | Gauge header vertical offset in px
+| header_wrap | `boolean` | `false` | Allow the header to span multiple lines, preserving newlines in `name` instead of truncating with an ellipsis
 | gauge_type | `standard`, `half`, `full` | `standard` | Gauge style type, standard for 270°, half for 180° and full for 360° style
 | rotate_gauge | `boolean`, | `false` | When true full gauge is rotated 180° so it starts from the top
 | gauge_radius | `number` | `47` | Gauge radius

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -359,7 +359,7 @@ export class ModernCircularGauge extends LitElement {
       )}
     >
       ${this._config.show_header ? html`
-      <div class="header" style=${styleMap({ "--gauge-header-font-size": this._config.header_font_size ? `${this._config.header_font_size}px` : undefined,
+      <div class="header${this._config.header_wrap ? " wrap" : ""}" style=${styleMap({ "--gauge-header-font-size": this._config.header_font_size ? `${this._config.header_font_size}px` : undefined,
         "transform": this._config.header_offset ? `translate(0, ${this._config.header_offset}px)` : undefined })}>
         <p class="name${this._config.header_wrap ? " wrap" : ""}">
           ${this._templateResults?.name?.result ?? (isTemplate(String(this._config.name)) ? "" : this._config.name) ?? (attributes ? attributes.friendly_name : "")}
@@ -455,7 +455,7 @@ export class ModernCircularGauge extends LitElement {
         : undefined
       )}
       >
-      <div class="header" style=${styleMap({ "--gauge-header-font-size": this._config?.header_font_size ? `${this._config.header_font_size}px` : undefined,
+      <div class="header${this._config?.header_wrap ? " wrap" : ""}" style=${styleMap({ "--gauge-header-font-size": this._config?.header_font_size ? `${this._config.header_font_size}px` : undefined,
         "transform": this._config?.header_offset ? `translate(0, ${this._config.header_offset}px)` : undefined })}>
         <p class="name${this._config?.header_wrap ? " wrap" : ""}">
           ${headerText}
@@ -1490,6 +1490,14 @@ export class ModernCircularGauge extends LitElement {
     }
 
     .flex-column-reverse .header {
+      position: relative;
+    }
+
+    /* An absolutely positioned header is anchored at its static position, which
+       in this column-reverse card is its bottom edge, so extra lines grow up
+       into the dial and the state icon. Joining the flex flow reserves space
+       for the header instead, letting it grow downward. */
+    .header.wrap {
       position: relative;
     }
     

--- a/src/card/modern-circular-gauge.ts
+++ b/src/card/modern-circular-gauge.ts
@@ -361,7 +361,7 @@ export class ModernCircularGauge extends LitElement {
       ${this._config.show_header ? html`
       <div class="header" style=${styleMap({ "--gauge-header-font-size": this._config.header_font_size ? `${this._config.header_font_size}px` : undefined,
         "transform": this._config.header_offset ? `translate(0, ${this._config.header_offset}px)` : undefined })}>
-        <p class="name">
+        <p class="name${this._config.header_wrap ? " wrap" : ""}">
           ${this._templateResults?.name?.result ?? (isTemplate(String(this._config.name)) ? "" : this._config.name) ?? (attributes ? attributes.friendly_name : "")}
         </p>
       </div>
@@ -457,7 +457,7 @@ export class ModernCircularGauge extends LitElement {
       >
       <div class="header" style=${styleMap({ "--gauge-header-font-size": this._config?.header_font_size ? `${this._config.header_font_size}px` : undefined,
         "transform": this._config?.header_offset ? `translate(0, ${this._config.header_offset}px)` : undefined })}>
-        <p class="name">
+        <p class="name${this._config?.header_wrap ? " wrap" : ""}">
           ${headerText}
         </p>
       </div>
@@ -1574,6 +1574,12 @@ export class ModernCircularGauge extends LitElement {
       line-height: 20px;
       letter-spacing: .1px;
       color: var(--primary-text-color);
+    }
+
+    .name.wrap {
+      white-space: pre-line;
+      overflow: visible;
+      text-overflow: clip;
     }
 
     .unit {

--- a/src/card/type.ts
+++ b/src/card/type.ts
@@ -98,6 +98,7 @@ export interface ModernCircularGaugeConfig extends LovelaceCardConfig {
     state_font_family?: string;
     header_font_size?: number;
     header_offset?: number;
+    header_wrap?: boolean;
     start_from_zero?: boolean;
     inverted_mode?: boolean;
     gauge_width?: number;


### PR DESCRIPTION
### Problem

The header is styled `white-space: nowrap; overflow: hidden; text-overflow: ellipsis`. That is a sensible default — a long `friendly_name` should not wrap and push the dial around — but it also silently discards newlines in a **templated** `name`.

A fairly natural use is a header whose second line says how old the reading is:

```yaml
name: >-
  Office{% if stale %}
  {{ measured_at.strftime('%H:%M') }}{% endif %}
```

The template renders correctly and the newline is stored in the config, but on screen the time appears beside the label, and on a narrow card the ellipsis eats it outright (`Office 28…`). Nothing in the card config hints at the cause.

### Change

Adds `header_wrap` (boolean, default `false`). When set, the header preserves newlines, stops truncating, and grows downward:

```css
.name.wrap {
  white-space: pre-line;
  overflow: visible;
  text-overflow: clip;
}

.header.wrap {
  position: relative;
}
```

The second rule is the part I got wrong the first time round, so it is worth spelling out. `.header` is `position: absolute`, so it sits at its static position — and because `ha-card` is `flex-direction: column-reverse`, that static position is its **bottom** edge. A second line therefore grows *upward*, over the state icon and into the dial. Making a wrapping header join the flex flow reserves space for it instead, which is exactly what the existing `.flex-column-reverse .header` rule already does for `header_position: top`.

Strictly additive:

- Default is `false`, so neither class is ever applied and existing cards render byte-identically.
- `pre-line` preserves explicit newlines while still collapsing ordinary whitespace, so a long single-line name does not start wrapping unless the user opts in.
- `text-overflow: clip` because an ellipsis is meaningless once the text can wrap.

Five touch points, mirroring how `header_font_size` is wired: the type, the two header render sites, the stylesheet, and a README row.

### Testing

Built with `npm run build`; both rules and both render sites are present in `dist/`.

I have the equivalent CSS running on 157 gauges across four dashboards on my instance, applied via `card_mod`, and checked on the three clients I have: the Android companion app, a wall tablet, and desktop Chrome.

Two findings from that which motivated this PR, and which I should have checked before opening it:

- Via `card_mod` the declarations need `!important`, or the card's own `.name` rule wins. What made me think otherwise is that my desktop Chrome profile turned out to be injecting a `white-space: pre-line !important` user stylesheet, so the feature looked like it worked there while every other client still showed `Office 28…`. That is browser-level styling of a card's shadow DOM — fragile, invisible, and not something a card should require.
- Without the `.header` rule, the three `.name` declarations alone reproduce the upward-growth overlap described above. In `card_mod` I currently work around it with a hand-tuned `transform: translateY(9px)`. I tested `position: relative` on a live card side by side with the translated ones and it lays out identically, without the magic number, which is why the PR uses it rather than an offset.

If you would rather express this as a `--gauge-header-white-space` custom property, or fold it into the existing `header_*` options differently, I am happy to rework it.
